### PR TITLE
Fix select-nonee typo

### DIFF
--- a/app/(pages)/about-us.php/page.jsx
+++ b/app/(pages)/about-us.php/page.jsx
@@ -57,7 +57,7 @@ export const metadata = {
 export default function AboutUs() {
   return (
     <>
-      <div className="flex w-full relative bg-slate-50 select-nonee lg:h-dvh min-h-[650px]">
+      <div className="flex w-full relative bg-slate-50 select-none lg:h-dvh min-h-[650px]">
           <div className="size-full relative !z-10">
               <div className="flex size-full items-center rounded-b-2xl relative overflow-hidden shadow-lg before:absolute before:inset-0 before:bg-cover before:bg-right before:rounded-b-2xl before:bg-gradient-to-r before:mix-blend-multiply shadow-indigo-950 before:from-indigo-950/30 before:via-indigo-900/30 before:to-indigo-800/20">
                   <span className="absolute inset-0 bg-cover bg-right opacity-80 rounded-b-2xl bg-gradient-to-r mix-blend-multiply shadow-indigo-950 from-indigo-950/80 via-indigo-900/80 to-indigo-800/90"></span>
@@ -99,7 +99,7 @@ export default function AboutUs() {
               </div>
           </div>
       </div>
-      <div className="relative bg-white py-6 md:py-8 lg:py-16 select-nonee">
+      <div className="relative bg-white py-6 md:py-8 lg:py-16 select-none">
           <div className="mx-auto max-w-7xl px-6 lg:px-8 w-full">
             
               <div className="mx-auto max-w-container gap-7 flex md:flex-row-reverse flex-col max-lg:gap-4 items-center">
@@ -214,7 +214,7 @@ export default function AboutUs() {
               </div>
           </div>
       </div>
-      <div className="relative bg-gray-100 py-6 md:py-8 lg:py-16 select-nonee">
+      <div className="relative bg-gray-100 py-6 md:py-8 lg:py-16 select-none">
           <div className="mx-auto max-w-7xl px-6 lg:px-8 w-full relative">
             
               <div className="mx-auto max-w-container gap-7 flex flex-col max-lg:gap-4 items-center">
@@ -283,7 +283,7 @@ export default function AboutUs() {
 
 
       </div>
-      <div className="relative bg-white py-6 md:py-8 lg:py-16 select-nonee">
+      <div className="relative bg-white py-6 md:py-8 lg:py-16 select-none">
           <div className="mx-auto max-w-7xl px-6 lg:px-8 w-full">
             
               <div className="mx-auto max-w-container gap-7 flex md:flex-row flex-col max-lg:gap-4 items-center">
@@ -335,7 +335,7 @@ export default function AboutUs() {
               </div>
           </div>
       </div>
-      <div className="relative bg-gray-900 py-6 md:py-8 lg:py-16 select-nonee">
+      <div className="relative bg-gray-900 py-6 md:py-8 lg:py-16 select-none">
           <div className="mx-auto max-w-7xl px-6 lg:px-8 w-full relative">
             
               <div className="mx-auto max-w-container gap-7 flex flex-col max-lg:gap-4 items-center">

--- a/app/(pages)/career.php/page.jsx
+++ b/app/(pages)/career.php/page.jsx
@@ -56,7 +56,7 @@ export const metadata = {
 export default function Career() {
     return (
         <>
-          <div className="flex w-full relative bg-slate-50 select-nonee lg:h-dvh">
+          <div className="flex w-full relative bg-slate-50 select-none lg:h-dvh">
               <div className="size-full relative !z-10">
                   <div className="colorApply1 flex size-full items-center justify-center rounded-b-2xl relative overflow-hidden shadow-lg before:absolute before:inset-0 before:bg-cover before:bg-right before:rounded-b-2xl before:bg-gradient-to-r before:mix-blend-multiply shadow-green-950 before:from-green-950 before:via-green-900 before:to-green-800">
                       <span className="colorApply2 absolute inset-0 bg-cover bg-right opacity-50 rounded-b-2xl bg-gradient-to-r mix-blend-multiply shadow-green-950 from-green-950 via-green-900 to-green-800"></span>
@@ -93,7 +93,7 @@ export default function Career() {
                   </div>
               </div>
           </div>
-          <div className="relative bg-gray-100 py-6 md:py-8 lg:py-16 select-nonee">
+          <div className="relative bg-gray-100 py-6 md:py-8 lg:py-16 select-none">
               <div className="mx-auto max-w-7xl px-6 lg:px-8 w-full relative">
                 
                   <div className="mx-auto max-w-container gap-7 flex flex-col max-lg:gap-4 items-center">
@@ -241,7 +241,7 @@ export default function Career() {
               </div>
               <div className="mx-auto max-w-7xl px-6 lg:px-8 z-[1] relative">
 
-                  <div className="py-xl-5 py-lg-5 py-md-5 py-5 sm:w-3/4 w-full mx-auto select-nonee relative">
+                  <div className="py-xl-5 py-lg-5 py-md-5 py-5 sm:w-3/4 w-full mx-auto select-none relative">
                       <div className="flex w-full h-auto items-center flex-wrap">
                           <div className="lg:w-[60%] lg:pe-10 pe-0 w-[100%] lg:order-1 order-2">
                               <div className="">
@@ -488,7 +488,7 @@ export default function Career() {
                 
               </div>
           </div>
-          <div className="py-6 md:py-8 lg:py-16 select-nonee relative bg-gray-100 -z-[-1]">
+          <div className="py-6 md:py-8 lg:py-16 select-none relative bg-gray-100 -z-[-1]">
               <div className="mx-auto max-w-7xl px-6 lg:px-8 relative">
                   <div className="">
                       <h2 className="

--- a/app/(pages)/casestudy.php/page.jsx
+++ b/app/(pages)/casestudy.php/page.jsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export default function CaseStudy() {
     return (
         <>
-        <div className="flex w-full relative bg-slate-50 select-nonee lg:h-dvh lg:min-h-[650px]">
+        <div className="flex w-full relative bg-slate-50 select-none lg:h-dvh lg:min-h-[650px]">
             <div className="size-full relative !z-10">
                 <div className="flex size-full items-center rounded-b-2xl relative overflow-hidden shadow-lg before:absolute before:inset-0 before:bg-cover before:bg-right before:rounded-b-2xl before:bg-gradient-to-r before:mix-blend-multiply shadow-indigo-950 before:from-indigo-950/30 before:via-indigo-900/30 before:to-indigo-800/20">
                     <span className="absolute inset-0 bg-cover bg-right opacity-80 rounded-b-2xl bg-gradient-to-r mix-blend-multiply shadow-indigo-950 from-indigo-950/80 via-indigo-900/80 to-indigo-800/90"></span>
@@ -39,7 +39,7 @@ export default function CaseStudy() {
                 </div>
             </div>
         </div>
-        <div className="relative py-6 md:py-8 lg:py-16 select-nonee px-10 max-sm:px-4 lg:mt-10 mt-20" id="allCaseStudy">
+        <div className="relative py-6 md:py-8 lg:py-16 select-none px-10 max-sm:px-4 lg:mt-10 mt-20" id="allCaseStudy">
             <div className="mx-auto max-w-7xl mb-24 last:mb-10 px-6 lg:px-8 w-full shadow-2xl shadow-red-800/60 bg-red-800 rounded-3xl *:relative *:z-10 relative">
                 <Image
                     

--- a/app/(pages)/disclaimer.php/page.jsx
+++ b/app/(pages)/disclaimer.php/page.jsx
@@ -1,7 +1,7 @@
 export default function Disclaimer() {
     return (
         <>
-            <div className="relative pt-16 md:pt-20 lg:pt-32 select-nonee">
+            <div className="relative pt-16 md:pt-20 lg:pt-32 select-none">
                 <div className="text-black/10">
                     <svg aria-hidden="true" className="absolute inset-0 h-full w-full">
                         <defs>

--- a/app/(pages)/testimonials.php/page.jsx
+++ b/app/(pages)/testimonials.php/page.jsx
@@ -8,7 +8,7 @@ import { Swiper, SwiperSlide, Autoplay } from '@/components/CustomSwiper';
 export default function Testimonials() {
     return (
         <>
-            <div className="flex w-full relative bg-slate-50 select-nonee lg:h-dvh">
+            <div className="flex w-full relative bg-slate-50 select-none lg:h-dvh">
                 <div className="size-full relative !z-10">
                     <div className="colorApply1 flex size-full items-center justify-center rounded-b-2xl relative overflow-hidden shadow-lg before:absolute before:inset-0 before:bg-cover before:bg-right before:rounded-b-2xl before:bg-gradient-to-r before:mix-blend-multiply shadow-sky-950 before:from-sky-950 before:via-sky-900 before:to-sky-800">
                         <span className="colorApply2 absolute inset-0 bg-cover bg-right opacity-50 rounded-b-2xl bg-gradient-to-r mix-blend-multiply shadow-sky-950 from-sky-950 via-sky-900 to-sky-800"></span>
@@ -40,7 +40,7 @@ export default function Testimonials() {
 
             <Testimonial/>
 
-            <div className="relative bg-gray-900 py-8 sm:py-16 select-nonee text-white">
+            <div className="relative bg-gray-900 py-8 sm:py-16 select-none text-white">
                 <div className="text-white/10">
                     <svg aria-hidden="true" className="absolute inset-0 h-full w-full">
                         <defs>
@@ -325,7 +325,7 @@ export default function Testimonials() {
                 </Swiper>
             </div>
 
-            <div className="relative bg-gray-50 py-6 md:py-8 lg:py-16 select-nonee">
+            <div className="relative bg-gray-50 py-6 md:py-8 lg:py-16 select-none">
                 <div className="mx-auto max-w-7xl px-6 lg:px-8 w-full">
                     <ul className="grid xl:grid-cols-3 md:grid-cols-2 grid-cols-1 gap-y-32 pt-16 gap-x-6">
                         <li className="relative group !h-auto">
@@ -513,7 +513,7 @@ export default function Testimonials() {
                         </svg>
                     </div>
                     <div className="mx-auto max-w-7xl px-6 lg:px-8 z-[1] relative">
-                        <div className="select-nonee relative">
+                        <div className="select-none relative">
                             <div className="flex w-full h-auto items-center flex-wrap">
                                 <div className="lg:w-[60%] lg:pe-10 pe-0 w-[100%] lg:order-1 order-2">
                                     <h2 className="

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -5,7 +5,7 @@ import Copyright from "@/components/Copyright"
 
 const Footer = () => {
     return (
-        <footer className="relative bg- bg-[#16161d] pt-8 sm:pt-16 select-nonee text-white">
+        <footer className="relative bg- bg-[#16161d] pt-8 sm:pt-16 select-none text-white">
             <div className="mx-auto max-w-7xl px-6 lg:px-8 z-[1] relative">
                 <AwardsRecognitions2 />
             </div>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -30,7 +30,7 @@ const Navbar = () => {
   }, []);
     return (
       <>
-        <header className="absolute top-0 left-0 right-0 z-[1010] bg-white select-nonee group-[body]/ns:fixed group-[body]/ns:animate-fixed-nav shadow-[0px_4px_4px_0px_#0000001F]">
+        <header className="absolute top-0 left-0 right-0 z-[1010] bg-white select-none group-[body]/ns:fixed group-[body]/ns:animate-fixed-nav shadow-[0px_4px_4px_0px_#0000001F]">
           <nav className="!container flex items-center justify-between xl:py-4 lg:py-3 py-4" aria-label="Global">
             <div className="flex lg:hidden mr-2">
               <label htmlFor="sideToggle" className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5">
@@ -1174,7 +1174,7 @@ const Navbar = () => {
         <input type="checkbox" className="peer/sideToggle hidden" name="sideToggle" id="sideToggle" />
         <label htmlFor="sideToggle" className="fixed inset-0 -z-[1011] backdrop-blur-xl bg-sky-950/70 peer-checked/sideToggle:z-[1010] peer-checked/sideToggle:opacity-100 opacity-0 duration-100"></label>
 
-        <div className="fixed flex flex-col h-screen inset-y-0 right-0 z-[1011] w-full overflow-y-auto bg-white select-nonee px-6 py-6 sm:max-w-sm peer-checked/sideToggle:translate-x-0 peer-checked/sideToggle:opacity-100 translate-x-full opacity-0 duration-300">
+        <div className="fixed flex flex-col h-screen inset-y-0 right-0 z-[1011] w-full overflow-y-auto bg-white select-none px-6 py-6 sm:max-w-sm peer-checked/sideToggle:translate-x-0 peer-checked/sideToggle:opacity-100 translate-x-full opacity-0 duration-300">
           <div className="flex items-center justify-between">
             <Link href="" className="-ml-1.5">
               <span className="sr-only">IMG</span>

--- a/components/awardsRecognitions/awardsRecognitions2.jsx
+++ b/components/awardsRecognitions/awardsRecognitions2.jsx
@@ -9,7 +9,7 @@ import 'swiper/css/navigation';
 
 const AwardsRecognitions2 = () => {
     return (
-      <div className="relative isolate overflow-hidden select-nonee">
+      <div className="relative isolate overflow-hidden select-none">
           <div className="w-full relative z-10">
               <div className="mx-auto grid items-center max-w-2xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none">
                   <div className="w-full">


### PR DESCRIPTION
## Summary
- fix CSS class typos from `select-nonee` to `select-none`
- run `npm run lint`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841b7825e8083288bc986f227b934bc