### PR TITLE
Add responsive sizes for homepage images

### DIFF
--- a/components/HomeHero.jsx
+++ b/components/HomeHero.jsx
@@ -40,7 +40,7 @@ export default function HomeHero() {
             modules={[Pagination]}
             >
                 {!isMobile ? (
-                    <Image 
+                    <Image
                         loading="lazy"
                         fill={true}
                         sizes="100vw"
@@ -52,7 +52,7 @@ export default function HomeHero() {
                     <Image
                         loading="lazy"
                         fill={true}
-                        sizes="(max-width: 768px) 100vw, 50vw"
+                        sizes="100vw"
                         src="https://d1y41eupgbwbb2.cloudfront.net/images/bgHeroMobile-768.webp"
                         alt="AI-Driven Digital Transformation Company"
                         className="my-auto w-full z-0 object-cover object-center pointer-events-none"
@@ -81,7 +81,7 @@ export default function HomeHero() {
                                     src="https://d1y41eupgbwbb2.cloudfront.net/images/heroBot-768.webp" 
                                     blurDataURL="https://d1y41eupgbwbb2.cloudfront.net/images/heroBot-768.webp" 
                                     placeholder="blur"
-                                    sizes="(max-width: 768px) 100vw, 50vw"
+                                    sizes="(max-width: 768px) 100vw, 58vw"
                                     width="815" 
                                     height="579" 
                                     alt="AI-Driven Digital Transformation Company" 
@@ -93,7 +93,7 @@ export default function HomeHero() {
                                     src="https://d1y41eupgbwbb2.cloudfront.net/images/heroBotMobile-384.webp" 
                                     blurDataURL="https://d1y41eupgbwbb2.cloudfront.net/images/heroBotMobile-384.webp" 
                                     placeholder="blur"
-                                    sizes="(max-width: 768px) 100vw, 339px"
+                                    sizes="100vw"
                                     width="339" 
                                     height="438" 
                                     alt="AI-Driven Digital Transformation Company" 
@@ -129,9 +129,9 @@ export default function HomeHero() {
                         </div>
                         <div className="md:w-7/12 w-full flex flex-col relative overflow-hidden">
                             {!isMobile ? (
-                                <Image loading='lazy' sizes="(max-width: 768px) 100vw, 797px" src="https://d1y41eupgbwbb2.cloudfront.net/images/heroBot2.webp" width="815" height="579" alt="Empowering Businesses AI-Driven Mobile Apps" title="Empowering Businesses AI-Driven Mobile Apps" className="absolute top-8 inset-x-0 bottom-0 size-full object-contain" />
+                                <Image loading='lazy' sizes="(max-width: 768px) 100vw, 58vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/heroBot2.webp" width="815" height="579" alt="Empowering Businesses AI-Driven Mobile Apps" title="Empowering Businesses AI-Driven Mobile Apps" className="absolute top-8 inset-x-0 bottom-0 size-full object-contain" />
                                     ) : (
-                                <Image loading='lazy' sizes="(max-width: 768px) 100vw, 40vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/heroBot2Mobile.webp" width="339" height="438" alt="Empowering Businesses AI-Driven Mobile Apps" title="Empowering Businesses AI-Driven Mobile Apps" className="size-full object-contain mx-auto max-w-96 max-md:aspect-[384/496]" />
+                                <Image loading='lazy' sizes="100vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/heroBot2Mobile.webp" width="339" height="438" alt="Empowering Businesses AI-Driven Mobile Apps" title="Empowering Businesses AI-Driven Mobile Apps" className="size-full object-contain mx-auto max-w-96 max-md:aspect-[384/496]" />
                             )}
                             <div className="w-full max-md:text-center md:hidden sm:py-7 py-7">
                                 <label htmlFor="leadPopup" className="cursor-pointer xl:text-base text-sm font-semibold text-white inline-flex items-center xl:py-3 py-2.5 xl:ps-6 ps-4 xl:pe-3 pe-2.5 xl:gap-3 gap-2 rounded-full bg-gradient-to-b from-[#4E94FF] to-[#216CFF] duration-500 hover:lg:ring-4 hover:lg:ring-inset hover:lg:ring-[#216CFF] group/btn">

--- a/components/HomePage/AdvanceTech.jsx
+++ b/components/HomePage/AdvanceTech.jsx
@@ -11,7 +11,7 @@ const AdvanceTech = () => {
                       <div className="lg:w-6/12 md:w-5/12 w-full md:sticky md:top-32">
                           <h2 className="w-full 2xl:text-4xl xl:text-3xl lg:text-2xl text-xl md:font-bold font-semibold text-white text-balance relative z-10">Future-ready Solutions, Powered By Smart Technology</h2>
                           <div className="w-full">
-                              <Image loading="lazy" width="683" height="455" src="https://d1y41eupgbwbb2.cloudfront.net/images/advanceTechImage.webp" alt="Future-ready Solutions, Powered By Smart Technology" className="w-full aspect-[683/455]"/>
+                              <Image loading="lazy" width="683" height="455" sizes="(max-width: 768px) 100vw, (min-width: 1024px) 50vw, 42vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/advanceTechImage.webp" alt="Future-ready Solutions, Powered By Smart Technology" className="w-full aspect-[683/455]"/>
                           </div>
                       </div>
                       <div className="lg:w-6/12 md:w-7/12 w-full rounded-3xl flex flex-col relative md:pl-8">

--- a/components/HomePage/Brands.jsx
+++ b/components/HomePage/Brands.jsx
@@ -21,8 +21,8 @@ const Brands = () => {
                           </div>
                       </div>
                       <div className="md:w-5/12 w-full max-md:px-10 rounded-3xl aspect-square flex items-center justify-center md:pt-24 relative max-md:-mt-8">
-                          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/svg/waveIcon2.svg" alt="Wave Icon" width={300} height={300} title="Wave Icon" className="size-full object-contain absolute inset-0 z-0 md:translate-y-5" />
-                          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/brandsImage.webp" alt="Brands" width={300} height={300} className="size-full object-contain object-bottom relative z-10 -translate-x-5 md:translate-y-1/4" />
+                          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/svg/waveIcon2.svg" alt="Wave Icon" width={300} height={300} sizes="(max-width: 768px) 100vw, 42vw" title="Wave Icon" className="size-full object-contain absolute inset-0 z-0 md:translate-y-5" />
+                          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/brandsImage.webp" alt="Brands" width={300} height={300} sizes="(max-width: 768px) 100vw, 42vw" className="size-full object-contain object-bottom relative z-10 -translate-x-5 md:translate-y-1/4" />
                       </div>
                   </div>
               </div>

--- a/components/HomePage/CaseStudy.jsx
+++ b/components/HomePage/CaseStudy.jsx
@@ -85,7 +85,7 @@ const CaseStudy = () => {
                                   </div>
                               </div>
                               <div className="md:w-4/12 w-full max-md:order-first rounded-3xl aspect-square flex items-center justify-center bg-gradient-to-br from-[#b47b00] to-[#FFAE00] p-6">
-                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyBlinkit.webp" alt="Blinkit" title="Blinkit" width="375" height="375" className="size-full object-contain object-center"/>
+                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyBlinkit.webp" alt="Blinkit" title="Blinkit" width="375" height="375" sizes="(max-width: 768px) 100vw, 33vw" className="size-full object-contain object-center"/>
                               </div>
                           </SwiperSlide>
                           <SwiperSlide className="swiper-slide !flex flex-wrap justify-between items-stretch bg-white rounded-3xl xl:p-12 md:p-8 py-6 px-4 gap-y-6">
@@ -128,7 +128,7 @@ const CaseStudy = () => {
                                   </div>
                               </div>
                               <div className="md:w-4/12 w-full max-md:order-first rounded-3xl aspect-square flex items-center justify-center bg-gradient-to-br from-[#FFC422] to-[#F07000] p-6">
-                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyAstro.webp" alt="Astrotalk" title="Astrotalk" width="375" height="375" className="size-full object-contain object-center"/>
+                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyAstro.webp" alt="Astrotalk" title="Astrotalk" width="375" height="375" sizes="(max-width: 768px) 100vw, 33vw" className="size-full object-contain object-center"/>
                               </div>
                           </SwiperSlide>
                           <SwiperSlide className="swiper-slide !flex flex-wrap justify-between items-stretch bg-white rounded-3xl xl:p-12 md:p-8 py-6 px-4 gap-y-6">
@@ -171,7 +171,7 @@ const CaseStudy = () => {
                                   </div>
                               </div>
                               <div className="md:w-4/12 w-full max-md:order-first rounded-3xl aspect-square flex items-center justify-center bg-gradient-to-br from-[#4070FF] to-[#063CDE] p-6">
-                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyzillow.webp" alt="Zillow" title="Zillow" width="375" height="375" className="size-full object-contain object-center"/>
+                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyzillow.webp" alt="Zillow" title="Zillow" width="375" height="375" sizes="(max-width: 768px) 100vw, 33vw" className="size-full object-contain object-center"/>
                               </div>
                           </SwiperSlide>
                           <SwiperSlide className="swiper-slide !flex flex-wrap justify-between items-stretch bg-white rounded-3xl xl:p-12 md:p-8 py-6 px-4 gap-y-6">
@@ -214,7 +214,7 @@ const CaseStudy = () => {
                                   </div>
                               </div>
                               <div className="md:w-4/12 w-full max-md:order-first rounded-3xl aspect-square flex items-center justify-center bg-gradient-to-br from-[#818181] to-[#040404] p-6">
-                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyUber.webp" alt="Uber" title="Uber" width="375" height="375" className="size-full object-contain object-center"/>
+                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyUber.webp" alt="Uber" title="Uber" width="375" height="375" sizes="(max-width: 768px) 100vw, 33vw" className="size-full object-contain object-center"/>
                               </div>
                           </SwiperSlide>
                           <SwiperSlide className="swiper-slide !flex flex-wrap justify-between items-stretch bg-white rounded-3xl xl:p-12 md:p-8 py-6 px-4 gap-y-6">
@@ -257,7 +257,7 @@ const CaseStudy = () => {
                                   </div>
                               </div>
                               <div className="md:w-4/12 w-full max-md:order-first rounded-3xl aspect-square flex items-center justify-center bg-gradient-to-br from-[#FD3A73] to-[#FF8258] p-6">
-                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyTinder.webp" alt="Tinder" title="Tinder" width="375" height="375" className="size-full object-contain object-center"/>
+                                  <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/caseStudyTinder.webp" alt="Tinder" title="Tinder" width="375" height="375" sizes="(max-width: 768px) 100vw, 33vw" className="size-full object-contain object-center"/>
                               </div>
                           </SwiperSlide>
                   </Swiper>

--- a/components/HomePage/Industries.jsx
+++ b/components/HomePage/Industries.jsx
@@ -17,7 +17,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="333"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, (min-width: 1280px) 25vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/bankingAndFinance.webp"
                                   alt="Banking and Finance Icon"
                                   title="Banking and Finance Icon"
@@ -32,7 +32,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="447"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/fantasySports.webp"
                                   alt="Fantasy Sports Icon"
                                   title="Fantasy Sports Icon"
@@ -47,7 +47,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="220"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, (min-width: 1280px) 17vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/healthcare.webp"
                                   alt="Healthcare Icon"
                                   title="Healthcare Icon"
@@ -62,7 +62,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="333"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/edTechSolution.webp"
                                   alt="EdTech Solution Icon"
                                   title="EdTech Solution Icon"
@@ -79,7 +79,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="333"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/travelAndTourism.webp"
                                   alt="Travel and Tourism Icon"
                                   title="Travel and Tourism Icon"
@@ -96,7 +96,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="675"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 100vw, 50vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/mediaAndEntertainment.webp"
                                   alt="Media and Entertainment Icon"
                                   title="Media and Entertainment Icon"
@@ -111,7 +111,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="333"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/retailAndECommerceApp.webp"
                                   alt="Retail and eCommerce App Icon"
                                   title="Retail and eCommerce App Icon"
@@ -126,7 +126,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="333"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/logisticsServicesApp.webp"
                                   alt="Logistics Services App Icon"
                                   title="Logistics Services App Icon"
@@ -143,7 +143,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="220"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, (min-width: 1280px) 17vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/socialApp.webp"
                                   alt="Social App Icon"
                                   title="Social App Icon"
@@ -158,7 +158,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="447"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/realEstate.webp"
                                   alt="Real Estate Icon"
                                   title="Real Estate Icon"
@@ -173,7 +173,7 @@ const Industries = () => {
                                   className="size-full object-cover duration-1000 group-hover/ind:scale-150"
                                   width="333"
                                   height="222"
-                                  
+                                  sizes="(max-width: 768px) 50vw, 33vw"
                                   loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/eventManagement.webp"
                                   alt="Event management Icon"
                                   title="Event management Icon"

--- a/components/HomePage/QuickInsight.jsx
+++ b/components/HomePage/QuickInsight.jsx
@@ -4,7 +4,7 @@ import Image from "next/image"
 const QuickInsight = () => {
     return (
       <section className="quickInsightSection w-full relative overflow-hidden bg-white">
-          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioBg.webp" alt="Portfolio Background" width="1340" height="523" className="absolute inset-0 top-1/2 w-full z-0 pointer-events-none max-md:hidden"/>
+          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioBg.webp" alt="Portfolio Background" width="1340" height="523" sizes="100vw" className="absolute inset-0 top-1/2 w-full z-0 pointer-events-none max-md:hidden"/>
           <div className="!container flex relative z-10">
               <div className="flex flex-col w-full">
                   <div className="flex flex-wrap justify-between">
@@ -12,13 +12,13 @@ const QuickInsight = () => {
                           <h2 className="w-full 2xl:text-4xl xl:text-3xl lg:text-2xl text-xl md:font-bold font-semibold text-[#454444] text-balance relative z-10">A Quick Insight into <span className="text-[#2D86FF]">IMG</span> <span className="text-[#FF6B39]">Global Infotech</span></h2>
                           <div className="md:text-sm text-xs font-normal text-[#454444] line-clamp-3 pt-4">Step into the future with cutting-edge services and reshape the digital landscape with state-of-the-art solutions. Our dynamic work environment fosters creativity and collaboration to fuel groundbreaking ideas.</div>
                           <div className="w-full md:pt-20 max-md:hidden">
-                              <Image loading="lazy" width="569" height="321" src="https://d1y41eupgbwbb2.cloudfront.net/images/svg/quickInsightImage.svg" className="w-full h-auto aspect-[569/321]" alt="QuickInsight" title="QuickInsight"/>
+                              <Image loading="lazy" width="569" height="321" sizes="(max-width: 768px) 100vw, 42vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/svg/quickInsightImage.svg" className="w-full h-auto aspect-[569/321]" alt="QuickInsight" title="QuickInsight"/>
                           </div>
                       </div>
                       <div className="md:w-7/12 w-full rounded-3xl flex items-center justify-center relative md:pl-8">
-                          <Image loading="lazy" width="765" height="539" src="https://d1y41eupgbwbb2.cloudfront.net/images/quickInsightDesktop.webp" alt="A Quick Insight into IMG Global Infotech" className="w-full relative z-0 max-md:hidden aspect-[765/539]"/>
+                          <Image loading="lazy" width="765" height="539" sizes="(max-width: 768px) 100vw, 58vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/quickInsightDesktop.webp" alt="A Quick Insight into IMG Global Infotech" className="w-full relative z-0 max-md:hidden aspect-[765/539]"/>
 
-                          <Image loading="lazy" width="386" height="475" src="https://d1y41eupgbwbb2.cloudfront.net/images/quickInsightMobile.webp" alt="A Quick Insight into IMG Global Infotech" className="w-full relative z-0 md:hidden aspect-[386/475]"/>
+                          <Image loading="lazy" width="386" height="475" sizes="100vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/quickInsightMobile.webp" alt="A Quick Insight into IMG Global Infotech" className="w-full relative z-0 md:hidden aspect-[386/475]"/>
                       </div>
                   </div>
               </div>

--- a/components/cta/Cta1.jsx
+++ b/components/cta/Cta1.jsx
@@ -20,8 +20,8 @@ const Cta1 = () => {
                           </div>
                       </div>
                       <div className="md:w-5/12 w-full rounded-3xl flex items-center justify-center relative max-md:order-first max-md:pt-8">
-                          <Image loading="lazy" width={256} height={256} src="https://d1y41eupgbwbb2.cloudfront.net/images/svg/waveIcon1.svg" alt="Wave Icon" title="Wave Icon" className="md:size-64 size-40 object-contain max-md:m-auto absolute sm:inset-16 inset-0 z-0 md:-mb-28 md:-translate-x-1/4"/>
-                          <Image loading="lazy" width={256} height={256} src="https://d1y41eupgbwbb2.cloudfront.net/images/cta1Image.webp" alt="If You're a Person Who think out of the Box & Dream Big" className="size-full object-contain object-bottom relative z-10 mix-blend-hard-light"/>
+                          <Image loading="lazy" width={256} height={256} sizes="(max-width: 768px) 100vw, 42vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/svg/waveIcon1.svg" alt="Wave Icon" title="Wave Icon" className="md:size-64 size-40 object-contain max-md:m-auto absolute sm:inset-16 inset-0 z-0 md:-mb-28 md:-translate-x-1/4"/>
+                          <Image loading="lazy" width={256} height={256} sizes="(max-width: 768px) 100vw, 42vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/cta1Image.webp" alt="If You're a Person Who think out of the Box & Dream Big" className="size-full object-contain object-bottom relative z-10 mix-blend-hard-light"/>
                       </div>
                   </div>
               </div>

--- a/components/cta/Cta2.jsx
+++ b/components/cta/Cta2.jsx
@@ -21,7 +21,7 @@ const Cta2 = () => {
                             </div>
                         </div>
                         <div className="lg:w-6/12 md:w-1/2 max-md:-mx-4 rounded-3xl overflow-hidden flex md:flex-row flex-col items-center justify-center relative max-md:order-first before:max-md:hidden before:h-full before:w-0 before:shadow-[0px_0px_40px_60px_#13262d] before:z-20 after:md:h-full after:h-0 after:md:w-0 after:w-full after:shadow-[0px_0px_40px_60px_#13262d] after:z-20">
-                            <Image loading="lazy" width={683} height={415} src="https://d1y41eupgbwbb2.cloudfront.net/images/cta2Image.webp" alt="Let's turn your business idea into reality" title="Let's turn your business idea into reality" className="size-full object-cover object-center relative z-10"/>
+                            <Image loading="lazy" width={683} height={415} sizes="(max-width: 768px) 100vw, 50vw" src="https://d1y41eupgbwbb2.cloudfront.net/images/cta2Image.webp" alt="Let's turn your business idea into reality" title="Let's turn your business idea into reality" className="size-full object-cover object-center relative z-10"/>
                         </div>
                     </div>
                 </div>

--- a/components/portfolios/Portfolio1.jsx
+++ b/components/portfolios/Portfolio1.jsx
@@ -9,7 +9,7 @@ import { Swiper, SwiperSlide, Autoplay } from '@/components/CustomSwiper';
 const Portfolio1= () => {
     return (
       <section className="portfolioSection w-full relative overflow-hidden bg-white">
-          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioBg.webp" alt="Portfolio Background" width="1340" height="523" className="absolute inset-0 pt-8 size-full z-0 pointer-events-none max-md:hidden"/>
+          <Image loading="lazy" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioBg.webp" alt="Portfolio Background" width="1340" height="523" sizes="100vw" className="absolute inset-0 pt-8 size-full z-0 pointer-events-none max-md:hidden"/>
           <div className="!container flex xl:py-16 lg:py-14 md:py-12 sm:py-10 py-8 z-10 relative">
               <div className="flex flex-col w-full">
                   <div className="flex flex-wrap justify-between relative">
@@ -47,7 +47,7 @@ const Portfolio1= () => {
                                   <div className="w-full flex justify-center lg:pt-8 md:pt-4 pt-9">
                                       <div className="lg:max-w-[350px] md:max-w-[250px] w-full aspect-square relative">
                                           <Svg name="polygon1" className="size-full object-contain max-md:m-auto absolute inset-0 z-0 max-md:scale-90 group-[.swiper-slide-active]/p:rotate-0 rotate-45 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500 text-[#EC6C6C]" />
-                                          <Image loading="lazy" width={385} height={385} src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioFreshee.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
+                                          <Image loading="lazy" width={385} height={385} sizes="(max-width: 768px) 100vw, 350px" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioFreshee.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
                                       </div>
                                   </div>
                                   <div className="w-full md:hidden pt-8 text-center">
@@ -65,7 +65,7 @@ const Portfolio1= () => {
                                   <div className="w-full flex justify-center lg:pt-8 md:pt-4 pt-9">
                                       <div className="lg:max-w-[350px] md:max-w-[250px] w-full aspect-square relative">
                                           <Svg name="polygon1" className="size-full object-contain max-md:m-auto absolute inset-0 z-0 max-md:scale-90 group-[.swiper-slide-active]/p:rotate-0 rotate-45 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500 text-[#E5CC76]" />
-                                          <Image loading="lazy" width={385} height={385} src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioFebIndia.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
+                                          <Image loading="lazy" width={385} height={385} sizes="(max-width: 768px) 100vw, 350px" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioFebIndia.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
                                       </div>
                                   </div>
                                   <div className="w-full md:hidden pt-8 text-center">
@@ -83,7 +83,7 @@ const Portfolio1= () => {
                                   <div className="w-full flex justify-center lg:pt-8 md:pt-4 pt-9">
                                       <div className="lg:max-w-[350px] md:max-w-[250px] w-full aspect-square relative">
                                           <Svg name="polygon1" className="size-full object-contain max-md:m-auto absolute inset-0 z-0 max-md:scale-90 group-[.swiper-slide-active]/p:rotate-0 rotate-45 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500 text-[#7AD7F4]" />
-                                          <Image loading="lazy" width={385} height={385} src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioEdoovi.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
+                                          <Image loading="lazy" width={385} height={385} sizes="(max-width: 768px) 100vw, 350px" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioEdoovi.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
                                       </div>
                                   </div>
                                   <div className="w-full md:hidden pt-8 text-center">
@@ -101,7 +101,7 @@ const Portfolio1= () => {
                                   <div className="w-full flex justify-center lg:pt-8 md:pt-4 pt-9">
                                       <div className="lg:max-w-[350px] md:max-w-[250px] w-full aspect-square relative">
                                           <Svg name="polygon1" className="size-full object-contain max-md:m-auto absolute inset-0 z-0 max-md:scale-90 group-[.swiper-slide-active]/p:rotate-0 rotate-45 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500 text-[#FAC216]" />
-                                          <Image loading="lazy" width={385} height={385} src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioTaximo.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
+                                          <Image loading="lazy" width={385} height={385} sizes="(max-width: 768px) 100vw, 350px" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioTaximo.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
                                       </div>
                                   </div>
                                   <div className="w-full md:hidden pt-8 text-center">
@@ -119,7 +119,7 @@ const Portfolio1= () => {
                                   <div className="w-full flex justify-center lg:pt-8 md:pt-4 pt-9">
                                       <div className="lg:max-w-[350px] md:max-w-[250px] w-full aspect-square relative">
                                           <Svg name="polygon1" className="size-full object-contain max-md:m-auto absolute inset-0 z-0 max-md:scale-90 group-[.swiper-slide-active]/p:rotate-0 rotate-45 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500 text-[#F76900]" />
-                                          <Image loading="lazy" width={385} height={385} src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioFlexo.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
+                                          <Image loading="lazy" width={385} height={385} sizes="(max-width: 768px) 100vw, 350px" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioFlexo.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
                                       </div>
                                   </div>
                                   <div className="w-full md:hidden pt-8 text-center">
@@ -137,7 +137,7 @@ const Portfolio1= () => {
                                   <div className="w-full flex justify-center lg:pt-8 md:pt-4 pt-9">
                                       <div className="lg:max-w-[350px] md:max-w-[250px] w-full aspect-square relative">
                                           <Svg name="polygon1" className="size-full object-contain max-md:m-auto absolute inset-0 z-0 max-md:scale-90 group-[.swiper-slide-active]/p:rotate-0 rotate-45 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500 text-[#DA0C0C]" />
-                                          <Image loading="lazy" width={385} height={385} src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioPropira.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
+                                          <Image loading="lazy" width={385} height={385} sizes="(max-width: 768px) 100vw, 350px" src="https://d1y41eupgbwbb2.cloudfront.net/images/portfolioPropira.webp" alt="Moda Market" className="size-full object-contain object-center relative z-10 -mt-[8%] -ml-[8%] group-[.swiper-slide-active]/p:scale-110 scale-0 group-[.swiper-slide-active]/p:opacity-100 opacity-0 duration-500"/>
                                       </div>
                                   </div>
                                   <div className="w-full md:hidden pt-8 text-center">


### PR DESCRIPTION
## Summary
- update home hero images to use 100vw and 58vw sizes
- add responsive `sizes` attributes for various homepage sections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c89b93748328a3c8d436c9dac33c