### PR TITLE
Add simple page preloader

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,5 +1,6 @@
 import { Poppins } from "next/font/google";
 import "@/app/globals.css";
+import Preloader from "@/components/Preloader";
 
 const poppins = Poppins({
   weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"], // choose weights you want
@@ -146,7 +147,7 @@ export default function RootLayout({ children }) {
       <body
         className={`${poppins.variable} antialiased scroll font-poppins group overflow-x-hidden overflow-y-auto has-[.leadPopup:checked]:overflow-hidden`}
       >
-        {children}
+        <Preloader>{children}</Preloader>
       </body>
     </html>
   );

--- a/components/Preloader.jsx
+++ b/components/Preloader.jsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+export default function Preloader({ children }) {
+  const pathname = usePathname();
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [routeLoading, setRouteLoading] = useState(false);
+
+  // Initial load
+  useEffect(() => {
+    const timeout = setTimeout(() => setInitialLoading(false), 700);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  // Route change
+  useEffect(() => {
+    if (!initialLoading) {
+      setRouteLoading(true);
+      const timeout = setTimeout(() => setRouteLoading(false), 500);
+      return () => clearTimeout(timeout);
+    }
+  }, [pathname, initialLoading]);
+
+  const show = initialLoading || routeLoading;
+  return (
+    <>
+      {show && (
+        <div className="fixed inset-0 z-[2000] flex items-center justify-center bg-white transition-opacity">
+          <div
+            className={`border-[#000019] border-t-transparent border-4 rounded-full animate-spin ${initialLoading ? 'h-16 w-16' : 'h-12 w-12'}`}
+          />
+        </div>
+      )}
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Preloader` component to display a spinner on initial load and during route changes
- wrap the app in `Preloader`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426e949e648328845340ec095e69ca