### PR TITLE
Implement page transition preloader

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -186,3 +186,44 @@ body {
   font-family: var(--font-poppins), sans-serif;
 }
 
+
+.page-transition {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  transform: translateY(100%);
+  pointer-events: none;
+}
+
+.page-transition-inner {
+  width: 100%;
+  height: 100%;
+  background: var(--page-loader-bg, #000019);
+}
+
+.animate-page-in {
+  animation: pageSlideIn 0.6s forwards;
+}
+
+.animate-page-out {
+  animation: pageSlideOut 0.6s forwards;
+}
+
+@keyframes pageSlideIn {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes pageSlideOut {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-100%);
+  }
+}
+

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,5 +1,6 @@
 import { Poppins } from "next/font/google";
 import "@/app/globals.css";
+import PageTransition from "@/components/PageTransition";
 
 const poppins = Poppins({
   weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"], // choose weights you want
@@ -146,7 +147,7 @@ export default function RootLayout({ children }) {
       <body
         className={`${poppins.variable} antialiased scroll font-poppins group overflow-x-hidden overflow-y-auto has-[.leadPopup:checked]:overflow-hidden`}
       >
-        {children}
+        <PageTransition>{children}</PageTransition>
       </body>
     </html>
   );

--- a/components/PageTransition.jsx
+++ b/components/PageTransition.jsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Router from 'next/router';
+
+export default function PageTransition({ children }) {
+  const [show, setShow] = useState(false);
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    let timeout;
+
+    const handleStart = () => {
+      clearTimeout(timeout);
+      setShow(true);
+      requestAnimationFrame(() => setActive(true));
+    };
+
+    const handleComplete = () => {
+      setActive(false);
+      timeout = setTimeout(() => setShow(false), 600);
+    };
+
+    Router.events.on('routeChangeStart', handleStart);
+    Router.events.on('routeChangeComplete', handleComplete);
+    Router.events.on('routeChangeError', handleComplete);
+
+    return () => {
+      Router.events.off('routeChangeStart', handleStart);
+      Router.events.off('routeChangeComplete', handleComplete);
+      Router.events.off('routeChangeError', handleComplete);
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return (
+    <>
+      {show && (
+        <div
+          className={`page-transition ${active ? 'animate-page-in' : 'animate-page-out'}`}
+          aria-hidden="true"
+        >
+          <div className="page-transition-inner" />
+        </div>
+      )}
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create `PageTransition` component to handle route change animation
- wrap pages with `PageTransition` in the root layout
- add CSS for sliding loader animation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684276e0a7a8832888b28d0b12d2323d