### PR TITLE
Disable header clicks for 1s after navigation

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -6,12 +6,11 @@ import Link from 'next/link';
 import Svg from '@/components/svg';
 const Navbar = () => {
   const headerRef = useRef(null);
+  const sidebar = useRef(null);
+  const sidebarChecked = useRef(null);
 
   const handleHeaderClick = (event) => {
     if (event.target.closest('a')) {
-      const toggle = document.getElementById('sideToggle');
-      if (toggle) toggle.checked = false;
-
       const el = headerRef.current;
       if (el) {
         el.style.pointerEvents = 'none';
@@ -23,6 +22,15 @@ const Navbar = () => {
       }
     }
   };
+
+  const handleSidebarClick = (event) => {
+    if (event.target.closest('a')) {
+      if (sidebarChecked.current) {
+        sidebarChecked.current.checked = false;
+      }
+    }
+  };
+
   useEffect(() => {
     // Remove "group" class just once on mount
     if (document.body?.classList?.contains('group')) {
@@ -1193,10 +1201,13 @@ const Navbar = () => {
           </nav>
         </header>
 
-        <input type="checkbox" className="peer/sideToggle hidden" name="sideToggle" id="sideToggle" />
+        <input ref={sidebarChecked} type="checkbox" className="peer/sideToggle hidden" name="sideToggle" id="sideToggle" />
         <label htmlFor="sideToggle" className="fixed inset-0 -z-[1011] backdrop-blur-xl bg-sky-950/70 peer-checked/sideToggle:z-[1010] peer-checked/sideToggle:opacity-100 opacity-0 duration-100"></label>
 
-        <div className="fixed flex flex-col h-screen inset-y-0 right-0 z-[1011] w-full overflow-y-auto bg-white select-none px-6 py-6 sm:max-w-sm peer-checked/sideToggle:translate-x-0 peer-checked/sideToggle:opacity-100 translate-x-full opacity-0 duration-300">
+        <div
+          ref={sidebar}
+          onClickCapture={handleSidebarClick}
+          className="fixed flex flex-col h-screen inset-y-0 right-0 z-[1011] w-full overflow-y-auto bg-white select-none px-6 py-6 sm:max-w-sm peer-checked/sideToggle:translate-x-0 peer-checked/sideToggle:opacity-100 -translate-x-full opacity-0 duration-300">
           <div className="flex items-center justify-between">
             <Link href="" className="-ml-1.5">
               <span className="sr-only">IMG</span>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -9,12 +9,15 @@ const Navbar = () => {
 
   const handleHeaderClick = (event) => {
     if (event.target.closest('a')) {
+      const toggle = document.getElementById('sideToggle');
+      if (toggle) toggle.checked = false;
+
       const el = headerRef.current;
       if (el) {
         el.style.pointerEvents = 'none';
         setTimeout(() => {
           if (el) {
-            el.style.pointerEvents = '';
+            el.style.pointerEvents = 'auto';
           }
         }, 1000);
       }

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -1,10 +1,25 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import Svg from '@/components/svg';
 const Navbar = () => {
+  const headerRef = useRef(null);
+
+  const handleHeaderClick = (event) => {
+    if (event.target.closest('a')) {
+      const el = headerRef.current;
+      if (el) {
+        el.style.pointerEvents = 'none';
+        setTimeout(() => {
+          if (el) {
+            el.style.pointerEvents = '';
+          }
+        }, 1000);
+      }
+    }
+  };
   useEffect(() => {
     // Remove "group" class just once on mount
     if (document.body?.classList?.contains('group')) {
@@ -30,7 +45,11 @@ const Navbar = () => {
   }, []);
     return (
       <>
-        <header className="absolute top-0 left-0 right-0 z-[1010] bg-white select-none group-[body]/ns:fixed group-[body]/ns:animate-fixed-nav shadow-[0px_4px_4px_0px_#0000001F]">
+        <header
+          ref={headerRef}
+          onClickCapture={handleHeaderClick}
+          className="absolute top-0 left-0 right-0 z-[1010] bg-white select-none group-[body]/ns:fixed group-[body]/ns:animate-fixed-nav shadow-[0px_4px_4px_0px_#0000001F]"
+        >
           <nav className="!container flex items-center justify-between xl:py-4 lg:py-3 py-4" aria-label="Global">
             <div className="flex lg:hidden mr-2">
               <label htmlFor="sideToggle" className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5">


### PR DESCRIPTION
## Summary
- prevent rapid multi-clicks on header links by disabling pointer events for one second after any link click

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843147ff12c8328b5c914a24fd407ee