### PR TITLE
Fix CSP for blob images and add DialogDescription

### DIFF
--- a/app/actions/authors.js
+++ b/app/actions/authors.js
@@ -104,9 +104,9 @@ export async function createAuthor(formData) {
     // Revalidate the authors list page
     revalidatePath('/admin/blogs/authors');
     
-    return { 
+    return {
       success: true,
-      data: author
+      data: author.toJSON()
     };
   } catch (error) {
     console.error('Author creation error:', error);

--- a/app/middleware/security.js
+++ b/app/middleware/security.js
@@ -19,7 +19,7 @@ export function securityMiddleware(req) {
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  response.headers.set('Content-Security-Policy', "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';");
+  response.headers.set('Content-Security-Policy', "default-src 'self'; img-src 'self' blob: data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';");
   response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
   return response;

--- a/components/image-cropper-input.jsx
+++ b/components/image-cropper-input.jsx
@@ -56,6 +56,7 @@ function ImageCropperInput({ aspectRatio = 1, value, onChange, className }) {
         <DialogContent className="max-w-xl">
           <DialogHeader>
             <DialogTitle>Crop Image</DialogTitle>
+            <DialogDescription>Select the area of the image you want to keep.</DialogDescription>
           </DialogHeader>
           {imageSrc && (
             <Cropper

--- a/middleware.js
+++ b/middleware.js
@@ -38,7 +38,7 @@ export async function middleware(request) {
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  response.headers.set('Content-Security-Policy', "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';");
+  response.headers.set('Content-Security-Policy', "default-src 'self'; img-src 'self' blob: data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';");
   response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
 


### PR DESCRIPTION
## Summary
- allow blob URLs in the Content Security Policy so image previews work
- serialize created author objects before returning from server actions
- add a short description to the cropper dialog for accessibility

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685010ea88c083289289515a4ea7786c