### PR TITLE
Fix author creation serialization

### DIFF
--- a/app/actions/authors.js
+++ b/app/actions/authors.js
@@ -104,9 +104,12 @@ export async function createAuthor(formData) {
     // Revalidate the authors list page
     revalidatePath('/admin/blogs/authors');
     
+    const authorResponse = author.toObject();
+    authorResponse._id = authorResponse._id.toString();
+
     return {
       success: true,
-      data: author.toJSON()
+      data: authorResponse
     };
   } catch (error) {
     console.error('Author creation error:', error);


### PR DESCRIPTION
## Summary
- fix the `createAuthor` server action to return a serializable plain object

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850130c40a88328902f4179ccdba2b9