### PR TITLE
Add blog category CRUD

### DIFF
--- a/app/actions/categories.js
+++ b/app/actions/categories.js
@@ -1,0 +1,92 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import Category from '@/app/models/Category';
+import connectDB from '@/app/lib/db';
+
+export async function createCategory(formData) {
+  try {
+    await connectDB();
+
+    const name = formData.get('category_name')?.trim();
+    const description = formData.get('description')?.trim();
+
+    if (!name || !description) {
+      return { success: false, error: 'Please fill in all required fields' };
+    }
+    if (name.length > 100) {
+      return { success: false, error: 'Category name cannot exceed 100 characters' };
+    }
+    if (description.length > 500) {
+      return { success: false, error: 'Description cannot exceed 500 characters' };
+    }
+
+    const existingCategory = await Category.findOne({ category_name: name });
+    if (existingCategory) {
+      return { success: false, error: 'A category with this name already exists' };
+    }
+
+    const category = new Category({ category_name: name, description, status: 1 });
+    await category.save();
+
+    revalidatePath('/admin/blogs/categories');
+
+    const catRes = category.toObject();
+    catRes._id = catRes._id.toString();
+
+    return { success: true, data: catRes };
+  } catch (error) {
+    console.error('Category creation error:', error);
+    return { success: false, error: error.message || 'Failed to create category' };
+  }
+}
+
+export async function updateCategory(id, formData) {
+  try {
+    await connectDB();
+
+    const category = await Category.findById(id);
+    if (!category) {
+      return { success: false, error: 'Category not found' };
+    }
+
+    const name = formData.get('category_name')?.trim();
+    if (name && name !== category.category_name) {
+      if (name.length > 100) {
+        return { success: false, error: 'Category name cannot exceed 100 characters' };
+      }
+      const existing = await Category.findOne({ category_name: name, _id: { $ne: id } });
+      if (existing) {
+        return { success: false, error: 'A category with this name already exists' };
+      }
+      category.category_name = name;
+    }
+
+    const description = formData.get('description')?.trim();
+    if (description) {
+      if (description.length > 500) {
+        return { success: false, error: 'Description cannot exceed 500 characters' };
+      }
+      category.description = description;
+    }
+
+    const status = Number(formData.get('status'));
+    if ([1, 2, 3].includes(status)) {
+      category.status = status;
+    }
+
+    category.modified_date = new Date();
+    await category.save();
+
+    revalidatePath('/admin/blogs/categories');
+    revalidatePath(`/admin/blogs/categories/${id}`);
+
+    const updated = category.toObject();
+    updated._id = updated._id.toString();
+
+    return { success: true, data: updated };
+  } catch (error) {
+    console.error('Category update error:', error);
+    return { success: false, error: error.message || 'Failed to update category' };
+  }
+}

--- a/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
+++ b/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
@@ -1,0 +1,141 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { updateCategory } from "@/app/actions/categories";
+
+const categoryFormSchema = z.object({
+  category_name: z.string()
+    .min(2, { message: "Category name must be at least 2 characters" })
+    .max(100, { message: "Category name cannot exceed 100 characters" }),
+  description: z.string()
+    .min(10, { message: "Description must be at least 10 characters" })
+    .max(500, { message: "Description cannot exceed 500 characters" }),
+  status: z.number().optional(),
+});
+
+export default function EditCategoryForm({ category }) {
+  const router = useRouter();
+  const form = useForm({
+    resolver: zodResolver(categoryFormSchema),
+    defaultValues: {
+      category_name: category.category_name || "",
+      description: category.description || "",
+      status: category.status || 1,
+    },
+  });
+
+  async function onSubmit(data) {
+    try {
+      const formData = new FormData();
+      formData.append("category_name", data.category_name.trim());
+      formData.append("description", data.description.trim());
+      formData.append("status", String(data.status || 1));
+      const result = await updateCategory(category._id, formData);
+      if (result.success) {
+        toast.success("Category updated successfully!");
+        router.push(`/admin/blogs/categories/${category._id}`);
+        router.refresh();
+      } else {
+        toast.error(result.error || "Failed to update category");
+      }
+    } catch (error) {
+      toast.error("An unexpected error occurred");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Edit Category</CardTitle>
+          <CardDescription>Update category details below.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+              <FormField
+                control={form.control}
+                name="category_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Category Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Technology" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Brief description about the category"
+                        className="min-h-[120px]"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Status</FormLabel>
+                    <Select onValueChange={(value) => field.onChange(Number(value))} value={String(field.value)}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select status" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="1">Active</SelectItem>
+                        <SelectItem value="2">Inactive</SelectItem>
+                        <SelectItem value="3">Suspended</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-4">
+                <Button type="submit" disabled={form.formState.isSubmitting}>
+                  {form.formState.isSubmitting ? "Updating..." : "Update Category"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/edit/page.jsx
+++ b/app/admin/blogs/categories/[id]/edit/page.jsx
@@ -1,0 +1,30 @@
+import EditCategoryForm from "./EditCategoryForm";
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+export default async function Page({ params }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${params.id}`, { cache: 'no-store' });
+  const json = await res.json();
+  const category = json?.data;
+
+  if (!category) {
+    return <div className="p-4">Category not found</div>;
+  }
+
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="w-full p-4">
+        <EditCategoryForm category={category} />
+      </div>
+    </>
+  );
+}

--- a/app/admin/blogs/categories/[id]/page.jsx
+++ b/app/admin/blogs/categories/[id]/page.jsx
@@ -1,0 +1,59 @@
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import DeleteCategoryButtons from "@/components/delete-category-buttons";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default async function Page({ params }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${params.id}`, { cache: 'no-store' });
+  const json = await res.json();
+  const category = json?.data;
+
+  if (!category) {
+    return (
+      <div className="p-4">Category not found</div>
+    );
+  }
+
+  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
+
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="w-full p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Category Details</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2 text-sm">
+              <p><strong>Name:</strong> {category.category_name}</p>
+              <p><strong>Description:</strong> {category.description}</p>
+              <p><strong>Status:</strong> {statusMap[category.status]}</p>
+              <p><strong>Blogs:</strong> {category.blog_count}</p>
+              <p><strong>Created:</strong> {new Date(category.created_date).toLocaleString()}</p>
+              {category.deleted_at && (
+                <p><strong>Deleted:</strong> {new Date(category.deleted_at).toLocaleString()}</p>
+              )}
+            </div>
+            <div className="mt-4 flex gap-2">
+              <Link href={`/admin/blogs/categories/${category._id}/edit`}>
+                <Button type="button">Edit</Button>
+              </Link>
+              <DeleteCategoryButtons id={category._id} />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/app/admin/blogs/categories/add/page.jsx
+++ b/app/admin/blogs/categories/add/page.jsx
@@ -1,0 +1,135 @@
+"use client";
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { toast } from "sonner";
+import { createCategory } from "@/app/actions/categories";
+
+const categoryFormSchema = z.object({
+  category_name: z.string()
+    .min(2, { message: "Category name must be at least 2 characters" })
+    .max(100, { message: "Category name cannot exceed 100 characters" }),
+  description: z.string()
+    .min(10, { message: "Description must be at least 10 characters" })
+    .max(500, { message: "Description cannot exceed 500 characters" }),
+});
+
+export default function Page() {
+  const form = useForm({
+    resolver: zodResolver(categoryFormSchema),
+    defaultValues: {
+      category_name: "",
+      description: "",
+    },
+  });
+  async function onSubmit(data) {
+    try {
+      const formData = new FormData();
+      formData.append('category_name', data.category_name.trim());
+      formData.append('description', data.description.trim());
+      const result = await createCategory(formData);
+      if (result.success) {
+        toast.success("Category created successfully!");
+        form.reset();
+      } else {
+        toast.error(result.error || "Failed to create category");
+      }
+    } catch (error) {
+      toast.error("An unexpected error occurred");
+    }
+  }
+
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="w-full p-4">
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Add New Category</CardTitle>
+              <CardDescription>
+                Create a new blog category. Fill in the required information below.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+                  <FormField
+                    control={form.control}
+                    name="category_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Category Name</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Technology" {...field} />
+                        </FormControl>
+                        <FormDescription>
+                          This is the public name of the category.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="description"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Description</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            placeholder="Brief description about the category"
+                            className="min-h-[120px]"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Write a brief description about the category (max 500 characters)
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <div className="flex justify-end gap-4">
+                    <Button type="submit" disabled={form.formState.isSubmitting}>
+                      {form.formState.isSubmitting ? "Creating..." : "Create Category"}
+                    </Button>
+                  </div>
+                </form>
+              </Form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/admin/blogs/categories/page.jsx
+++ b/app/admin/blogs/categories/page.jsx
@@ -1,0 +1,35 @@
+import { CategoryTable } from "@/components/categoryTable";
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories`, { cache: 'no-store' });
+  const json = await res.json();
+  const categories = Array.isArray(json?.data) ? json.data : [];
+  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
+  const data = categories.map(cat => ({
+    id: cat._id,
+    category_name: cat.category_name,
+    description: cat.description,
+    status: statusMap[cat.status] || 'inactive',
+    created_date: cat.created_date,
+    modified_date: cat.modified_date,
+  }));
+
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+        <CategoryTable data={data} />
+      </div>
+    </>
+  );
+}

--- a/app/api/v1/admin/blogs/categories/[id]/route.js
+++ b/app/api/v1/admin/blogs/categories/[id]/route.js
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import mongoose from 'mongoose';
+import connectDB from '@/app/lib/db';
+import Category from '@/app/models/Category';
+import Blog from '@/app/models/Blog';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function GET(request, context) {
+  try {
+    await connectDB();
+
+    const id = context.params.id;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid category ID' }, { status: 400 });
+    }
+    const { searchParams } = new URL(request.url);
+    const showDeleted = searchParams.get('deleted') === 'true';
+
+    const query = { _id: id };
+    if (showDeleted) {
+      query.showDeleted = true;
+    }
+    const category = await Category.findOne(query).select('-__v');
+
+    if (!category) {
+      return NextResponse.json({ success: false, error: 'Category not found' }, { status: 404 });
+    }
+
+    const blogCount = await Blog.countDocuments({ categories: id, status: 'published' });
+    category.blog_count = blogCount;
+    await category.save();
+
+    return NextResponse.json({ success: true, data: category });
+
+  } catch (error) {
+    console.error('Error fetching category:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching category' }, { status: 500 });
+  }
+}
+
+export async function PUT(request, context) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+    await connectDB();
+
+    const id = context.params.id;
+    if (!id || !id.match(/^[0-9a-fA-F]{24}$/)) {
+      return NextResponse.json({ success: false, error: 'Invalid category ID format' }, { status: 400 });
+    }
+
+    const formData = await request.formData();
+    if (!formData) {
+      return NextResponse.json({ success: false, error: 'No form data provided' }, { status: 400 });
+    }
+
+    const category = await Category.findById(id);
+    if (!category) {
+      return NextResponse.json({ success: false, error: 'Category not found' }, { status: 404 });
+    }
+
+    const newName = formData.get('category_name');
+    if (newName && newName !== category.category_name) {
+      const existingCategory = await Category.findOne({ category_name: newName, _id: { $ne: id } });
+      if (existingCategory) {
+        return NextResponse.json({ success: false, error: 'Category with this name already exists' }, { status: 400 });
+      }
+      category.category_name = newName;
+    }
+
+    const newDescription = formData.get('description');
+    if (newDescription !== null) {
+      category.description = newDescription;
+    }
+
+    const status = Number(formData.get('status'));
+    if ([1, 2, 3].includes(status)) {
+      category.status = status;
+    }
+
+    category.modified_date = new Date();
+    await category.save();
+
+    const blogCount = await Blog.countDocuments({ categories: id, status: 'published' });
+    category.blog_count = blogCount;
+    await category.save();
+
+    return NextResponse.json({ success: true, data: category });
+
+  } catch (error) {
+    console.error('Error updating category:', error);
+    if (error.code === 11000) {
+      return NextResponse.json({ success: false, error: 'Category with this name already exists' }, { status: 400 });
+    }
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map(err => err.message);
+      return NextResponse.json({ success: false, error: messages.join(', ') }, { status: 400 });
+    }
+    return NextResponse.json({ success: false, error: 'Error updating category' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, context) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+    const id = context.params.id;
+    if (!id || !mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid category ID' }, { status: 400 });
+    }
+    const { searchParams } = new URL(request.url);
+    const force = searchParams.get('force') === 'true';
+
+    const category = await Category.findOne({ _id: id }, null, { showDeleted: true });
+    if (!category) {
+      return NextResponse.json({ success: false, error: 'Category not found' }, { status: 404 });
+    }
+    if (force) {
+      await Category.findByIdAndDelete(id, { showDeleted: true });
+      return NextResponse.json({ success: true, message: 'Category has been permanently deleted' });
+    }
+    if (category.deleted_at) {
+      return NextResponse.json({ success: true, message: 'Category is already soft deleted', data: category });
+    }
+    category.deleted_at = new Date();
+    await category.save();
+    return NextResponse.json({ success: true, message: 'Category has been soft deleted', data: category });
+  } catch (error) {
+    console.error('Error deleting category:', error);
+    return NextResponse.json({ success: false, error: 'Error deleting category' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/blogs/categories/route.js
+++ b/app/api/v1/admin/blogs/categories/route.js
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Category from '@/app/models/Category';
+import Blog from '@/app/models/Blog';
+import Fuse from 'fuse.js';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function GET(req) {
+  try {
+    await connectDB();
+    const { searchParams } = new URL(req.url);
+
+    const search = searchParams.get('search');
+    const showDeleted = searchParams.get('deleted') === 'true';
+    const status = searchParams.get('status');
+    const sortBy = searchParams.get('sortBy') || 'created_date';
+    const sortOrder = parseInt(searchParams.get('sortOrder')) || -1;
+    const page = parseInt(searchParams.get('page')) || 1;
+    const limit = parseInt(searchParams.get('limit')) || 10;
+    const skip = (page - 1) * limit;
+
+    const baseQuery = {};
+    if (!showDeleted) {
+      baseQuery.deleted_at = null;
+    }
+    if (status) {
+      const numericStatus = parseInt(status, 10);
+      if (![1, 2, 3].includes(numericStatus)) {
+        return NextResponse.json({
+          success: false,
+          error: 'Invalid status value. Must be 1 (Active), 2 (Inactive), or 3 (Suspended)'
+        }, { status: 400 });
+      }
+      baseQuery.status = numericStatus;
+    }
+
+    let allCategories = await Category.find(baseQuery).select('-__v').lean();
+
+    if (search) {
+      const fuseOptions = {
+        keys: ['category_name', 'description', 'slug'],
+        threshold: 0.3,
+        includeScore: true
+      };
+      const fuse = new Fuse(allCategories, fuseOptions);
+      const searchResults = fuse.search(search);
+      allCategories = searchResults.map(result => result.item);
+    }
+
+    const total = allCategories.length;
+
+    if (sortBy) {
+      allCategories.sort((a, b) => {
+        const aValue = a[sortBy];
+        const bValue = b[sortBy];
+        return sortOrder * (aValue > bValue ? 1 : -1);
+      });
+    }
+
+    const categories = allCategories.slice(skip, skip + limit);
+
+    const categoriesWithCounts = await Promise.all(categories.map(async (cat) => {
+      const blogCount = await Blog.countDocuments({ categories: cat._id, status: 'published' });
+      return { ...cat, blog_count: blogCount };
+    }));
+
+    return NextResponse.json({
+      success: true,
+      data: categoriesWithCounts,
+      pagination: {
+        total,
+        page,
+        limit,
+        pages: Math.ceil(total / limit)
+      }
+    });
+
+  } catch (error) {
+    console.error('Error fetching categories:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching categories' }, { status: 500 });
+  }
+}
+
+export async function POST(req) {
+  try {
+    const token = extractToken(req.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+
+    const formData = await req.formData();
+
+    const existingCategory = await Category.findOne({ category_name: formData.get('category_name') });
+    if (existingCategory) {
+      return NextResponse.json({ success: false, error: 'Category with this name already exists' }, { status: 400 });
+    }
+
+    const status = Number(formData.get('status')) || 1;
+    if (![1, 2, 3].includes(status)) {
+      return NextResponse.json({ success: false, error: 'Status must be 1 (Active), 2 (Inactive), or 3 (Suspended)' }, { status: 400 });
+    }
+
+    const categoryData = {
+      category_name: formData.get('category_name'),
+      description: formData.get('description'),
+      status: status
+    };
+
+    const category = await Category.create(categoryData);
+
+    return NextResponse.json({ success: true, data: category }, { status: 201 });
+
+  } catch (error) {
+    console.error('Error creating category:', error);
+    if (error.code === 11000) {
+      return NextResponse.json({ success: false, error: 'Category with this name already exists' }, { status: 400 });
+    }
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map(err => err.message);
+      return NextResponse.json({ success: false, error: messages.join(', ') }, { status: 400 });
+    }
+    return NextResponse.json({ success: false, error: 'Error creating category' }, { status: 500 });
+  }
+}

--- a/app/models/Category.js
+++ b/app/models/Category.js
@@ -1,0 +1,88 @@
+import mongoose from 'mongoose';
+import slugify from 'slugify';
+
+const categorySchema = new mongoose.Schema({
+  status: {
+    type: Number,
+    enum: [1, 2, 3],
+    default: 1
+  },
+  deleted_at: {
+    type: Date,
+    default: null
+  },
+  category_name: {
+    type: String,
+    required: [true, 'Please provide category name'],
+    trim: true,
+    maxlength: [100, 'Category name cannot be more than 100 characters'],
+    unique: true
+  },
+  slug: {
+    type: String,
+    unique: true,
+    index: true,
+    required: true
+  },
+  description: {
+    type: String,
+    required: [true, 'Please provide category description'],
+    maxlength: [500, 'Description cannot be more than 500 characters']
+  },
+  created_date: {
+    type: Date,
+    default: Date.now
+  },
+  modified_date: {
+    type: Date,
+    default: Date.now
+  }
+}, {
+  timestamps: {
+    createdAt: 'created_date',
+    updatedAt: 'modified_date'
+  }
+});
+
+categorySchema.pre('validate', async function(next) {
+  if (this.isModified('category_name')) {
+    let baseSlug = slugify(this.category_name, {
+      lower: true,
+      strict: true,
+      trim: true
+    });
+
+    let slugExists = true;
+    let counter = 0;
+    let candidateSlug = baseSlug;
+
+    while (slugExists) {
+      const existing = await mongoose.models.Category.findOne({
+        slug: candidateSlug,
+        _id: { $ne: this._id }
+      });
+      if (!existing) {
+        slugExists = false;
+      } else {
+        counter += 1;
+        candidateSlug = `${baseSlug}-${counter}`;
+      }
+    }
+
+    this.slug = candidateSlug;
+  }
+  next();
+});
+
+categorySchema.index({ category_name: 'text', description: 'text' });
+
+categorySchema.pre(['find', 'findOne', 'countDocuments'], function() {
+  const showDeleted = this.getOptions().showDeleted;
+  if (!showDeleted && !this._conditions.deleted_at) {
+    this.where({ deleted_at: null });
+  }
+});
+
+const Category = mongoose.models.Category || mongoose.model('Category', categorySchema);
+
+export default Category;

--- a/components/categoryTable.jsx
+++ b/components/categoryTable.jsx
@@ -1,0 +1,323 @@
+"use client";
+import * as React from "react";
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowUpDown, ChevronDown, MoreHorizontal, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import TokenFromCookie from "@/helpers/tokenFromCookie";
+
+function CategoryActions({ category }) {
+  const router = useRouter();
+
+  const handleStatusChange = async (status) => {
+    try {
+      const formData = new FormData();
+      formData.append('status', status);
+      const token = TokenFromCookie();
+      const res = await fetch(`/api/v1/admin/blogs/categories/${category.id}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        body: formData,
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success('Status updated');
+        router.refresh();
+      } else {
+        toast.error(data.error || 'Failed to update status');
+      }
+    } catch (error) {
+      toast.error('Failed to update status');
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-8 w-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem onClick={() => navigator.clipboard.writeText(category.id)}>
+          Copy category ID
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href={`/admin/blogs/categories/${category.id}/edit`}>Edit</Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>Change Status</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem onClick={() => handleStatusChange(1)}>Active</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => handleStatusChange(2)}>Inactive</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => handleStatusChange(3)}>Suspend</DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export const columns = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "category_name",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Name
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+    cell: ({ row }) => (
+      <div className="font-medium">
+        <Link href={`/admin/blogs/categories/${row.original.id}`} className="hover:underline">
+          {row.getValue("category_name")}
+        </Link>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => (
+      <div className="line-clamp-2">{row.getValue("description")}</div>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      const status = row.getValue("status");
+      return (
+        <Badge variant={status === "active" ? "default" : "secondary"} className="capitalize">
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: "created_date",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Created Date
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+    cell: ({ row }) => {
+      const date = new Date(row.getValue("created_date"));
+      const formatted = new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+      return <div>{formatted}</div>;
+    },
+  },
+  {
+    id: "actions",
+    enableHiding: false,
+    cell: ({ row }) => <CategoryActions category={row.original} />,
+  },
+];
+
+export function CategoryTable({ data }) {
+  const [sorting, setSorting] = React.useState([]);
+  const [columnFilters, setColumnFilters] = React.useState([]);
+  const [columnVisibility, setColumnVisibility] = React.useState({});
+  const [rowSelection, setRowSelection] = React.useState({});
+
+  const table = useReactTable({
+    data,
+    columns,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+    },
+  });
+
+  return (
+    <div className="w-full">
+      <div className="flex gap-3 items-center py-4">
+        <Input
+          placeholder="Filter by name..."
+          value={table.getColumn("category_name")?.getFilterValue() ?? ""}
+          onChange={(event) =>
+            table.getColumn("category_name")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="ml-auto">
+              Columns <ChevronDown className="ml-2 h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {table
+              .getAllColumns()
+              .filter((column) => column.getCanHide())
+              .map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  className="capitalize"
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(value) =>
+                    column.toggleVisibility(!!value)
+                  }
+                >
+                  {column.id}
+                </DropdownMenuCheckboxItem>
+              ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button asChild>
+          <Link href="/admin/blogs/categories/add"><Plus /> Add Category</Link>
+        </Button>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <div className="text-muted-foreground flex-1 text-sm">
+          {table.getFilteredSelectedRowModel().rows.length} of{' '}
+          {table.getFilteredRowModel().rows.length} row(s) selected.
+        </div>
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/delete-category-buttons.jsx
+++ b/components/delete-category-buttons.jsx
@@ -1,0 +1,60 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import TokenFromCookie from "@/helpers/tokenFromCookie";
+
+export default function DeleteCategoryButtons({ id }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  const handleDelete = async () => {
+    try {
+      const token = TokenFromCookie();
+      const url = `/api/v1/admin/blogs/categories/${id}`;
+      const res = await fetch(url, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success(data.message || "Category deleted");
+        router.push("/admin/blogs/categories");
+      } else {
+        toast.error(data.error || "Failed to delete category");
+      }
+    } catch (error) {
+      toast.error("Failed to delete category");
+    } finally {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="destructive" className="mt-4 cursor-pointer">Delete</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Category</DialogTitle>
+          <DialogDescription>
+            This will soft delete the category. Continue?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete}>
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add Category model
- add API routes for blog categories
- add server actions for categories
- implement admin UI for categories (list/add/edit/detail)
- add table and delete components for categories

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68516e4560a88328bdf664789b4f2770