### PR TITLE
Fix uploads dir recreation for author images

### DIFF
--- a/app/middleware/imageUpload.js
+++ b/app/middleware/imageUpload.js
@@ -81,6 +81,9 @@ export async function uploadAuthorImage(file) {
       return fileType;
     }
 
+    // Ensure the authors directory exists in case it was deleted at runtime
+    await fs.mkdir(UPLOAD_DIRS.authors, { recursive: true });
+
     // Generate unique filename
     const filename = `author-${Date.now()}.webp`;
     const filepath = path.join(UPLOAD_DIRS.authors, filename);


### PR DESCRIPTION
## Summary
- ensure authors directory exists before saving uploaded author image

## Testing
- `npx next lint` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_685177aa555883289002466a39211c94