### PR TITLE
Add extended blog fields

### DIFF
--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -14,54 +14,111 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 import { updateBlog } from "@/app/actions/blogs";
 import RichTextEditor from "@/components/rich-text-editor";
+import ImageCropperInput from "@/components/image-cropper-input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 const blogSchema = z.object({
   title: z.string().min(2).max(200),
-  excerpt: z.string().min(10).max(500),
-  content: z.string().min(10),
-  author: z.string().min(1),
-  featured_image: z.any().optional(),
+  category: z.string().min(1),
+  authorId: z.string().min(1),
+  blogWrittenDate: z.string().optional(),
+  shortDescription: z.string().min(10).max(500),
+  description: z.string().min(10),
+  banner: z.any().optional(),
+  thumbnail: z.any().optional(),
+  imageAlt: z.string().optional(),
+  xImage: z.any().optional(),
+  xImageAlt: z.string().optional(),
+  ogImage: z.any().optional(),
+  ogImageAlt: z.string().optional(),
+  metaTitle: z.string().min(2).max(60),
+  metaKeyword: z.string().optional(),
+  metaDescription: z.string().min(2).max(160),
+  metaOgDescription: z.string().optional(),
+  metaOgTitle: z.string().optional(),
+  metaXTitle: z.string().optional(),
+  metaXDescription: z.string().optional(),
+  commentShowStatus: z.boolean().optional(),
   status: z.enum(["draft", "published", "archived"]).default("draft"),
-  meta_title: z.string().min(2).max(60),
-  meta_description: z.string().min(2).max(160),
+  publishedDateTime: z.string().optional(),
+  faq: z.string().optional(),
+  bgColor: z.string().optional(),
+  bgColorStatus: z.boolean().optional(),
 });
 
 export default function Page({ params }) {
   const form = useForm({ resolver: zodResolver(blogSchema) });
   const [authors, setAuthors] = useState([]);
+  const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     fetch(`/api/v1/admin/blogs/authors`).then(res => res.json()).then(json => {
       setAuthors(Array.isArray(json?.data) ? json.data : []);
     });
+    fetch(`/api/v1/admin/blogs/categories`).then(res => res.json()).then(json => {
+      setCategories(Array.isArray(json?.data) ? json.data : []);
+    });
     fetch(`/api/v1/admin/blogs/${params.id}`).then(res => res.json()).then(json => {
       const b = json?.data;
       if (b) {
         form.reset({
           title: b.title,
-          excerpt: b.excerpt,
-          content: b.content,
-          author: b.author?._id || '',
+          category: b.category?._id || '',
+          authorId: b.authorId || '',
+          blogWrittenDate: b.blogWrittenDate ? b.blogWrittenDate.split('T')[0] : '',
+          shortDescription: b.shortDescription,
+          description: b.description,
+          imageAlt: b.imageAlt || '',
+          xImageAlt: b.xImageAlt || '',
+          ogImageAlt: b.ogImageAlt || '',
+          metaTitle: b.metaTitle,
+          metaKeyword: b.metaKeyword || '',
+          metaDescription: b.metaDescription,
+          metaOgDescription: b.metaOgDescription || '',
+          metaOgTitle: b.metaOgTitle || '',
+          metaXTitle: b.metaXTitle || '',
+          metaXDescription: b.metaXDescription || '',
+          commentShowStatus: b.commentShowStatus,
           status: b.status,
-          meta_title: b.meta_title,
-          meta_description: b.meta_description,
+          publishedDateTime: b.publishedDateTime ? b.publishedDateTime.slice(0,16) : '',
+          faq: b.faq || '',
+          bgColor: b.bgColor || '',
+          bgColorStatus: b.bgColorStatus,
         });
       }
       setLoading(false);
     });
-  }, [params.id]);
+  }, [params.id, form]);
 
   async function onSubmit(data) {
     const formData = new FormData();
     formData.append('title', data.title.trim());
-    formData.append('excerpt', data.excerpt.trim());
-    formData.append('content', data.content);
-    formData.append('author', data.author);
-    if (data.featured_image?.[0]) formData.append('featured_image', data.featured_image[0]);
+    formData.append('category', data.category);
+    formData.append('authorId', data.authorId);
+    if (data.blogWrittenDate) formData.append('blogWrittenDate', data.blogWrittenDate);
+    formData.append('shortDescription', data.shortDescription.trim());
+    formData.append('description', data.description);
+    if (data.banner?.[0]) formData.append('banner', data.banner[0]);
+    if (data.thumbnail?.[0]) formData.append('thumbnail', data.thumbnail[0]);
+    if (data.xImage?.[0]) formData.append('xImage', data.xImage[0]);
+    if (data.ogImage?.[0]) formData.append('ogImage', data.ogImage[0]);
+    if (data.imageAlt) formData.append('imageAlt', data.imageAlt);
+    if (data.xImageAlt) formData.append('xImageAlt', data.xImageAlt);
+    if (data.ogImageAlt) formData.append('ogImageAlt', data.ogImageAlt);
     formData.append('status', data.status);
-    formData.append('meta_title', data.meta_title.trim());
-    formData.append('meta_description', data.meta_description.trim());
+    if (data.metaTitle) formData.append('metaTitle', data.metaTitle.trim());
+    if (data.metaKeyword) formData.append('metaKeyword', data.metaKeyword.trim());
+    if (data.metaDescription) formData.append('metaDescription', data.metaDescription.trim());
+    if (data.metaOgDescription) formData.append('metaOgDescription', data.metaOgDescription.trim());
+    if (data.metaOgTitle) formData.append('metaOgTitle', data.metaOgTitle.trim());
+    if (data.metaXTitle) formData.append('metaXTitle', data.metaXTitle.trim());
+    if (data.metaXDescription) formData.append('metaXDescription', data.metaXDescription.trim());
+    formData.append('commentShowStatus', data.commentShowStatus);
+    if (data.publishedDateTime) formData.append('publishedDateTime', data.publishedDateTime);
+    if (data.faq) formData.append('faq', data.faq);
+    if (data.bgColor) formData.append('bgColor', data.bgColor);
+    formData.append('bgColorStatus', data.bgColorStatus);
     const result = await updateBlog(params.id, formData);
     if (result.success) {
       toast.success("Blog updated successfully!");
@@ -90,107 +147,213 @@ export default function Page({ params }) {
           <CardContent>
             <Form {...form}>
               <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-                <FormField
-                  control={form.control}
-                  name="title"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Title</FormLabel>
-                      <FormControl><Input {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="excerpt"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Excerpt</FormLabel>
-                      <FormControl><Textarea {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="content"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Content</FormLabel>
-                      <FormControl><RichTextEditor value={field.value} onChange={field.onChange} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="author"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Author</FormLabel>
-                      <FormControl>
-                        <select {...field} className="border rounded px-2 py-1">
-                          <option value="">Select author</option>
-                          {authors.map(a => (
-                            <option key={a._id} value={a._id}>{a.author_name}</option>
+                <FormField control={form.control} name="title" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Title</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="category" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Category</FormLabel>
+                    <FormControl>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <SelectTrigger><SelectValue placeholder="Select category" /></SelectTrigger>
+                        <SelectContent>
+                          {categories.map(c => (
+                            <SelectItem key={c._id} value={c._id}>{c.category_name}</SelectItem>
                           ))}
-                        </select>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="featured_image"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Featured Image</FormLabel>
-                      <FormControl><Input type="file" accept="image/*" onChange={e => field.onChange(e.target.files)} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="status"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Status</FormLabel>
-                      <FormControl>
-                        <select {...field} className="border rounded px-2 py-1">
-                          <option value="draft">Draft</option>
-                          <option value="published">Published</option>
-                          <option value="archived">Archived</option>
-                        </select>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="meta_title"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Meta Title</FormLabel>
-                      <FormControl><Input {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="meta_description"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Meta Description</FormLabel>
-                      <FormControl><Textarea {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="authorId" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Author</FormLabel>
+                    <FormControl>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <SelectTrigger><SelectValue placeholder="Select author" /></SelectTrigger>
+                        <SelectContent>
+                          {authors.map(a => (
+                            <SelectItem key={a._id} value={a._id}>{a.author_name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="blogWrittenDate" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Written Date</FormLabel>
+                    <FormControl><Input type="date" {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="shortDescription" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Short Description</FormLabel>
+                    <FormControl><Textarea {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="description" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl><RichTextEditor value={field.value} onChange={field.onChange} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="banner" render={({ field: { onChange, value } }) => (
+                  <FormItem>
+                    <FormLabel>Banner</FormLabel>
+                    <FormControl><ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="thumbnail" render={({ field: { onChange, value } }) => (
+                  <FormItem>
+                    <FormLabel>Thumbnail</FormLabel>
+                    <FormControl><ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="imageAlt" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Image Alt</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="xImage" render={({ field: { onChange, value } }) => (
+                  <FormItem>
+                    <FormLabel>Extra Image</FormLabel>
+                    <FormControl><ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="xImageAlt" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Extra Image Alt</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="ogImage" render={({ field: { onChange, value } }) => (
+                  <FormItem>
+                    <FormLabel>OG Image</FormLabel>
+                    <FormControl><ImageCropperInput aspectRatio={1200/630} value={value} onChange={onChange} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="ogImageAlt" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>OG Image Alt</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="metaTitle" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Meta Title</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="metaKeyword" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Meta Keywords</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="metaDescription" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Meta Description</FormLabel>
+                    <FormControl><Textarea {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="metaOgDescription" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Meta OG Description</FormLabel>
+                    <FormControl><Textarea {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="metaOgTitle" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Meta OG Title</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="metaXTitle" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Meta X Title</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="metaXDescription" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Meta X Description</FormLabel>
+                    <FormControl><Textarea {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="commentShowStatus" render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl><input type="checkbox" checked={field.value} onChange={e => field.onChange(e.target.checked)} /></FormControl>
+                    <FormLabel>Show Comments</FormLabel>
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="status" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Status</FormLabel>
+                    <FormControl>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <SelectTrigger><SelectValue placeholder="Select status" /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="draft">Draft</SelectItem>
+                          <SelectItem value="published">Published</SelectItem>
+                          <SelectItem value="archived">Archived</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="publishedDateTime" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Publish Date</FormLabel>
+                    <FormControl><Input type="datetime-local" {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="faq" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>FAQ</FormLabel>
+                    <FormControl><Textarea {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="bgColor" render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Background Color</FormLabel>
+                    <FormControl><Input type="color" {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField control={form.control} name="bgColorStatus" render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                    <FormControl><input type="checkbox" checked={field.value} onChange={e => field.onChange(e.target.checked)} /></FormControl>
+                    <FormLabel>Enable Background Color</FormLabel>
+                  </FormItem>
+                )} />
                 <Button type="submit" disabled={form.formState.isSubmitting}>{form.formState.isSubmitting ? 'Saving...' : 'Save Changes'}</Button>
               </form>
             </Form>

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -14,37 +14,82 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 import { createBlog } from "@/app/actions/blogs";
 import RichTextEditor from "@/components/rich-text-editor";
+import ImageCropperInput from "@/components/image-cropper-input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 const blogSchema = z.object({
   title: z.string().min(2).max(200),
-  excerpt: z.string().min(10).max(500),
-  content: z.string().min(10),
-  author: z.string().min(1),
-  featured_image: z.any().refine((file) => file?.length === 1, "Image is required"),
+  category: z.string().min(1),
+  authorId: z.string().min(1),
+  blogWrittenDate: z.string().optional(),
+  shortDescription: z.string().min(10).max(500),
+  description: z.string().min(10),
+  banner: z.any().refine((file) => file?.length === 1, "Banner is required"),
+  thumbnail: z.any().optional(),
+  imageAlt: z.string().optional(),
+  xImage: z.any().optional(),
+  xImageAlt: z.string().optional(),
+  ogImage: z.any().optional(),
+  ogImageAlt: z.string().optional(),
+  metaTitle: z.string().min(2).max(60),
+  metaKeyword: z.string().optional(),
+  metaDescription: z.string().min(2).max(160),
+  metaOgDescription: z.string().optional(),
+  metaOgTitle: z.string().optional(),
+  metaXTitle: z.string().optional(),
+  metaXDescription: z.string().optional(),
+  commentShowStatus: z.boolean().optional().default(true),
   status: z.enum(["draft", "published", "archived"]).default("draft"),
-  meta_title: z.string().min(2).max(60),
-  meta_description: z.string().min(2).max(160),
+  publishedDateTime: z.string().optional(),
+  faq: z.string().optional(),
+  bgColor: z.string().optional(),
+  bgColorStatus: z.boolean().optional(),
 });
 
 export default function Page() {
-  const form = useForm({ resolver: zodResolver(blogSchema), defaultValues: { status: "draft" } });
+  const form = useForm({
+    resolver: zodResolver(blogSchema),
+    defaultValues: { status: "draft", commentShowStatus: true, bgColorStatus: false }
+  });
   const [authors, setAuthors] = useState([]);
+  const [categories, setCategories] = useState([]);
   useEffect(() => {
     fetch(`/api/v1/admin/blogs/authors`).then(res => res.json()).then(json => {
       setAuthors(Array.isArray(json?.data) ? json.data : []);
+    });
+    fetch(`/api/v1/admin/blogs/categories`).then(res => res.json()).then(json => {
+      setCategories(Array.isArray(json?.data) ? json.data : []);
     });
   }, []);
 
   async function onSubmit(data) {
     const formData = new FormData();
     formData.append('title', data.title.trim());
-    formData.append('excerpt', data.excerpt.trim());
-    formData.append('content', data.content);
-    formData.append('author', data.author);
-    if (data.featured_image?.[0]) formData.append('featured_image', data.featured_image[0]);
+    formData.append('category', data.category);
+    formData.append('authorId', data.authorId);
+    if (data.blogWrittenDate) formData.append('blogWrittenDate', data.blogWrittenDate);
+    formData.append('shortDescription', data.shortDescription.trim());
+    formData.append('description', data.description);
+    if (data.banner?.[0]) formData.append('banner', data.banner[0]);
+    if (data.thumbnail?.[0]) formData.append('thumbnail', data.thumbnail[0]);
+    if (data.xImage?.[0]) formData.append('xImage', data.xImage[0]);
+    if (data.ogImage?.[0]) formData.append('ogImage', data.ogImage[0]);
+    if (data.imageAlt) formData.append('imageAlt', data.imageAlt);
+    if (data.xImageAlt) formData.append('xImageAlt', data.xImageAlt);
+    if (data.ogImageAlt) formData.append('ogImageAlt', data.ogImageAlt);
     formData.append('status', data.status);
-    formData.append('meta_title', data.meta_title.trim());
-    formData.append('meta_description', data.meta_description.trim());
+    if (data.metaTitle) formData.append('metaTitle', data.metaTitle.trim());
+    if (data.metaKeyword) formData.append('metaKeyword', data.metaKeyword.trim());
+    if (data.metaDescription) formData.append('metaDescription', data.metaDescription.trim());
+    if (data.metaOgDescription) formData.append('metaOgDescription', data.metaOgDescription.trim());
+    if (data.metaOgTitle) formData.append('metaOgTitle', data.metaOgTitle.trim());
+    if (data.metaXTitle) formData.append('metaXTitle', data.metaXTitle.trim());
+    if (data.metaXDescription) formData.append('metaXDescription', data.metaXDescription.trim());
+    formData.append('commentShowStatus', data.commentShowStatus);
+    if (data.publishedDateTime) formData.append('publishedDateTime', data.publishedDateTime);
+    if (data.faq) formData.append('faq', data.faq);
+    if (data.bgColor) formData.append('bgColor', data.bgColor);
+    formData.append('bgColorStatus', data.bgColorStatus);
     const result = await createBlog(formData);
     if (result.success) {
       toast.success("Blog created successfully!");
@@ -78,46 +123,8 @@ export default function Page() {
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>Title</FormLabel>
-                      <FormControl><Input {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="excerpt"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Excerpt</FormLabel>
-                      <FormControl><Textarea {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="content"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Content</FormLabel>
-                      <FormControl><RichTextEditor value={field.value} onChange={field.onChange} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="author"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Author</FormLabel>
                       <FormControl>
-                        <select {...field} className="border rounded px-2 py-1">
-                          <option value="">Select author</option>
-                          {authors.map(a => (
-                            <option key={a._id} value={a._id}>{a.author_name}</option>
-                          ))}
-                        </select>
+                        <Input {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -125,12 +132,278 @@ export default function Page() {
                 />
                 <FormField
                   control={form.control}
-                  name="featured_image"
+                  name="category"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Featured Image</FormLabel>
-                      <FormControl><Input type="file" accept="image/*" onChange={e => field.onChange(e.target.files)} /></FormControl>
+                      <FormLabel>Category</FormLabel>
+                      <FormControl>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select category" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {categories.map(c => (
+                              <SelectItem key={c._id} value={c._id}>{c.category_name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
                       <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="authorId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Author</FormLabel>
+                      <FormControl>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select author" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {authors.map(a => (
+                              <SelectItem key={a._id} value={a._id}>{a.author_name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="blogWrittenDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Written Date</FormLabel>
+                      <FormControl>
+                        <Input type="date" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="shortDescription"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Short Description</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <RichTextEditor value={field.value} onChange={field.onChange} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="banner"
+                  render={({ field: { onChange, value } }) => (
+                    <FormItem>
+                      <FormLabel>Banner</FormLabel>
+                      <FormControl>
+                        <ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="thumbnail"
+                  render={({ field: { onChange, value } }) => (
+                    <FormItem>
+                      <FormLabel>Thumbnail</FormLabel>
+                      <FormControl>
+                        <ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="imageAlt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Image Alt</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="xImage"
+                  render={({ field: { onChange, value } }) => (
+                    <FormItem>
+                      <FormLabel>Extra Image</FormLabel>
+                      <FormControl>
+                        <ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="xImageAlt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Extra Image Alt</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="ogImage"
+                  render={({ field: { onChange, value } }) => (
+                    <FormItem>
+                      <FormLabel>OG Image</FormLabel>
+                      <FormControl>
+                        <ImageCropperInput aspectRatio={1200/630} value={value} onChange={onChange} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="ogImageAlt"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>OG Image Alt</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metaTitle"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meta Title</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metaKeyword"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meta Keywords</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metaDescription"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meta Description</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metaOgDescription"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meta OG Description</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metaOgTitle"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meta OG Title</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metaXTitle"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meta X Title</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metaXDescription"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Meta X Description</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="commentShowStatus"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                      <FormControl>
+                        <input type="checkbox" checked={field.value} onChange={e => field.onChange(e.target.checked)} />
+                      </FormControl>
+                      <FormLabel>Show Comments</FormLabel>
                     </FormItem>
                   )}
                 />
@@ -141,11 +414,16 @@ export default function Page() {
                     <FormItem>
                       <FormLabel>Status</FormLabel>
                       <FormControl>
-                        <select {...field} className="border rounded px-2 py-1">
-                          <option value="draft">Draft</option>
-                          <option value="published">Published</option>
-                          <option value="archived">Archived</option>
-                        </select>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select status" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="draft">Draft</SelectItem>
+                            <SelectItem value="published">Published</SelectItem>
+                            <SelectItem value="archived">Archived</SelectItem>
+                          </SelectContent>
+                        </Select>
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -153,23 +431,52 @@ export default function Page() {
                 />
                 <FormField
                   control={form.control}
-                  name="meta_title"
+                  name="publishedDateTime"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Meta Title</FormLabel>
-                      <FormControl><Input {...field} /></FormControl>
+                      <FormLabel>Publish Date</FormLabel>
+                      <FormControl>
+                        <Input type="datetime-local" {...field} />
+                      </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
                 <FormField
                   control={form.control}
-                  name="meta_description"
+                  name="faq"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Meta Description</FormLabel>
-                      <FormControl><Textarea {...field} /></FormControl>
+                      <FormLabel>FAQ</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} />
+                      </FormControl>
                       <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="bgColor"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Background Color</FormLabel>
+                      <FormControl>
+                        <Input type="color" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="bgColorStatus"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                      <FormControl>
+                        <input type="checkbox" checked={field.value} onChange={e => field.onChange(e.target.checked)} />
+                      </FormControl>
+                      <FormLabel>Enable Background Color</FormLabel>
                     </FormItem>
                   )}
                 />

--- a/app/api/v1/admin/blogs/[id]/route.js
+++ b/app/api/v1/admin/blogs/[id]/route.js
@@ -41,28 +41,78 @@ export async function PUT(req, { params }) {
     const formData = await req.formData();
     const title = formData.get('title');
     if (title) blog.title = title.trim();
-    const excerpt = formData.get('excerpt');
-    if (excerpt) blog.excerpt = excerpt.trim();
-    const content = formData.get('content');
-    if (content) blog.content = content.trim();
-    const author = formData.get('author');
-    if (author) blog.author = author;
-    const cats = formData.get('categories');
-    if (cats) blog.categories = cats.split(',').filter(Boolean);
-    const status = formData.get('status');
-    if (status) blog.status = status;
-    const metaTitle = formData.get('meta_title');
-    if (metaTitle) blog.meta_title = metaTitle.trim();
-    const metaDesc = formData.get('meta_description');
-    if (metaDesc) blog.meta_description = metaDesc.trim();
-    const imgFile = formData.get('featured_image');
-    if (imgFile && typeof imgFile !== 'string') {
-      const img = await uploadBlogImage(imgFile);
+    const shortDescription = formData.get('shortDescription');
+    if (shortDescription) blog.shortDescription = shortDescription.trim();
+    const description = formData.get('description');
+    if (description) blog.description = description.trim();
+    const authorId = formData.get('authorId');
+    if (authorId) blog.authorId = authorId;
+    const category = formData.get('category');
+    if (category) blog.category = category;
+    const bannerFile = formData.get('banner');
+    if (bannerFile && typeof bannerFile !== 'string') {
+      const img = await uploadBlogImage(bannerFile);
       if (!img.success) {
         return NextResponse.json({ success: false, error: img.error }, { status: 400 });
       }
-      blog.featured_image = img.filename;
+      blog.banner = img.filename;
     }
+    const thumbFile = formData.get('thumbnail');
+    if (thumbFile && typeof thumbFile !== 'string') {
+      const img = await uploadBlogImage(thumbFile);
+      if (!img.success) {
+        return NextResponse.json({ success: false, error: img.error }, { status: 400 });
+      }
+      blog.thumbnail = img.filename;
+    }
+    const ogFile = formData.get('ogImage');
+    if (ogFile && typeof ogFile !== 'string') {
+      const img = await uploadBlogImage(ogFile, 1200, 630);
+      if (!img.success) {
+        return NextResponse.json({ success: false, error: img.error }, { status: 400 });
+      }
+      blog.ogImage = img.filename;
+    }
+    const xFile = formData.get('xImage');
+    if (xFile && typeof xFile !== 'string') {
+      const img = await uploadBlogImage(xFile);
+      if (!img.success) {
+        return NextResponse.json({ success: false, error: img.error }, { status: 400 });
+      }
+      blog.xImage = img.filename;
+    }
+    const status = formData.get('status');
+    if (status) blog.status = status;
+    const metaTitle = formData.get('metaTitle');
+    if (metaTitle) blog.metaTitle = metaTitle.trim();
+    const metaKeyword = formData.get('metaKeyword');
+    if (metaKeyword) blog.metaKeyword = metaKeyword.trim();
+    const metaDesc = formData.get('metaDescription');
+    if (metaDesc) blog.metaDescription = metaDesc.trim();
+    const metaOgDesc = formData.get('metaOgDescription');
+    if (metaOgDesc) blog.metaOgDescription = metaOgDesc.trim();
+    const metaOgTitle = formData.get('metaOgTitle');
+    if (metaOgTitle) blog.metaOgTitle = metaOgTitle.trim();
+    const metaXTitle = formData.get('metaXTitle');
+    if (metaXTitle) blog.metaXTitle = metaXTitle.trim();
+    const metaXDesc = formData.get('metaXDescription');
+    if (metaXDesc) blog.metaXDescription = metaXDesc.trim();
+    const imageAlt = formData.get('imageAlt');
+    if (imageAlt) blog.imageAlt = imageAlt.trim();
+    const xImageAlt = formData.get('xImageAlt');
+    if (xImageAlt) blog.xImageAlt = xImageAlt.trim();
+    const ogImageAlt = formData.get('ogImageAlt');
+    if (ogImageAlt) blog.ogImageAlt = ogImageAlt.trim();
+    const publishedDateTime = formData.get('publishedDateTime');
+    if (publishedDateTime) blog.publishedDateTime = publishedDateTime;
+    const faq = formData.get('faq');
+    if (faq) blog.faq = faq;
+    const bgColor = formData.get('bgColor');
+    if (bgColor) blog.bgColor = bgColor;
+    const bgColorStatus = formData.get('bgColorStatus');
+    if (bgColorStatus !== null) blog.bgColorStatus = bgColorStatus === 'true';
+    const commentShowStatus = formData.get('commentShowStatus');
+    if (commentShowStatus !== null) blog.commentShowStatus = commentShowStatus === 'true';
     await blog.save();
     return NextResponse.json({ success: true, data: { ...blog.toObject(), id: blog._id.toString() } });
   } catch (error) {

--- a/app/api/v1/admin/blogs/route.js
+++ b/app/api/v1/admin/blogs/route.js
@@ -51,22 +51,54 @@ export async function POST(req) {
 
     await connectDB();
     const formData = await req.formData();
-    const imageFile = formData.get('featured_image');
-    const img = await uploadBlogImage(imageFile);
-    if (!img.success) {
-      return NextResponse.json({ success: false, error: img.error }, { status: 400 });
+    const bannerFile = formData.get('banner');
+    const banner = await uploadBlogImage(bannerFile);
+    if (!banner.success) {
+      return NextResponse.json({ success: false, error: banner.error }, { status: 400 });
+    }
+    const thumbFile = formData.get('thumbnail');
+    const thumb = thumbFile ? await uploadBlogImage(thumbFile) : { success: true };
+    if (thumb && !thumb.success) {
+      return NextResponse.json({ success: false, error: thumb.error }, { status: 400 });
+    }
+    const ogFile = formData.get('ogImage');
+    const ogImg = ogFile ? await uploadBlogImage(ogFile, 1200, 630) : { success: true };
+    if (ogImg && !ogImg.success) {
+      return NextResponse.json({ success: false, error: ogImg.error }, { status: 400 });
+    }
+    const xFile = formData.get('xImage');
+    const xImg = xFile ? await uploadBlogImage(xFile) : { success: true };
+    if (xImg && !xImg.success) {
+      return NextResponse.json({ success: false, error: xImg.error }, { status: 400 });
     }
 
     const blog = await Blog.create({
+      category: formData.get('category'),
       title: formData.get('title'),
-      excerpt: formData.get('excerpt'),
-      content: formData.get('content'),
-      author: formData.get('author'),
-      categories: formData.get('categories')?.split(',').filter(Boolean) || [],
-      featured_image: img.filename,
+      authorId: formData.get('authorId'),
+      blogWrittenDate: formData.get('blogWrittenDate') || new Date(),
+      shortDescription: formData.get('shortDescription'),
+      description: formData.get('description'),
+      banner: banner.filename,
+      thumbnail: thumb.filename,
+      imageAlt: formData.get('imageAlt') || '',
+      xImage: xImg.filename,
+      xImageAlt: formData.get('xImageAlt') || '',
+      ogImage: ogImg.filename,
+      ogImageAlt: formData.get('ogImageAlt') || '',
+      metaTitle: formData.get('metaTitle'),
+      metaKeyword: formData.get('metaKeyword'),
+      metaDescription: formData.get('metaDescription'),
+      metaOgDescription: formData.get('metaOgDescription'),
+      metaOgTitle: formData.get('metaOgTitle'),
+      metaXTitle: formData.get('metaXTitle'),
+      metaXDescription: formData.get('metaXDescription'),
+      commentShowStatus: formData.get('commentShowStatus') === 'true',
       status: formData.get('status') || 'draft',
-      meta_title: formData.get('meta_title'),
-      meta_description: formData.get('meta_description')
+      publishedDateTime: formData.get('publishedDateTime'),
+      faq: formData.get('faq'),
+      bgColor: formData.get('bgColor'),
+      bgColorStatus: formData.get('bgColorStatus') === 'true'
     });
 
     return NextResponse.json({ success: true, data: { ...blog.toObject(), id: blog._id.toString() } }, { status: 201 });

--- a/app/middleware/imageUpload.js
+++ b/app/middleware/imageUpload.js
@@ -114,7 +114,7 @@ export async function uploadAuthorImage(file) {
 initializeUploadDirs();
 
 // Upload and process blog image
-export async function uploadBlogImage(file) {
+export async function uploadBlogImage(file, width = 1080, height = 617) {
   try {
     if (!file) {
       return {
@@ -134,7 +134,7 @@ export async function uploadBlogImage(file) {
     const filepath = path.join(UPLOAD_DIRS.blogs, filename);
 
     await sharp(Buffer.from(buffer))
-      .resize(1080, 617, {
+      .resize(width, height, {
         fit: 'cover',
         position: 'center'
       })

--- a/app/models/Blog.js
+++ b/app/models/Blog.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import slugify from 'slugify';
 
 const blogSchema = new mongoose.Schema({
+  category: { type: mongoose.Schema.Types.ObjectId, ref: 'Category', required: true },
   title: {
     type: String,
     required: [true, 'Blog title is required'],
@@ -9,94 +10,54 @@ const blogSchema = new mongoose.Schema({
     maxlength: [200, 'Title cannot be more than 200 characters'],
     unique: true
   },
-  slug: {
+  authorId: { type: mongoose.Schema.Types.ObjectId, ref: 'Author', required: true },
+  blogWrittenDate: { type: Date, default: Date.now },
+  slug: { type: String, unique: true, index: true },
+  shortDescription: {
     type: String,
-    unique: true,
-    index: true
+    required: [true, 'Blog short description is required'],
+    maxlength: [500, 'Short description cannot be more than 500 characters']
   },
-  content: {
-    type: String,
-    required: [true, 'Blog content is required']
-  },
-  excerpt: {
-    type: String,
-    required: [true, 'Blog excerpt is required'],
-    maxlength: [500, 'Excerpt cannot be more than 500 characters']
-  },
-  author: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Author',
-    required: [true, 'Blog author is required']
-  },
-  categories: [{
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Category'
-  }],
-  tags: [{
-    type: String,
-    trim: true
-  }],
-  featured_image: {
-    type: String,
-    required: [true, 'Featured image is required']
-  },
-  status: {
-    type: String,
-    enum: ['draft', 'published', 'archived'],
-    default: 'draft'
-  },
-  meta_title: {
-    type: String,
-    required: [true, 'Meta title is required'],
-    maxlength: [60, 'Meta title cannot be more than 60 characters']
-  },
-  meta_description: {
-    type: String,
-    required: [true, 'Meta description is required'],
-    maxlength: [160, 'Meta description cannot be more than 160 characters']
-  },
-  views: {
-    type: Number,
-    default: 0
-  },
-  created_date: {
-    type: Date,
-    default: Date.now
-  },
-  modified_date: {
-    type: Date,
-    default: Date.now
-  }
+  description: { type: String, required: [true, 'Blog description is required'] },
+  banner: { type: String },
+  thumbnail: { type: String },
+  imageAlt: { type: String },
+  xImage: { type: String },
+  xImageAlt: { type: String },
+  ogImage: { type: String },
+  ogImageAlt: { type: String },
+  metaTitle: { type: String },
+  metaKeyword: { type: String },
+  metaDescription: { type: String },
+  metaOgDescription: { type: String },
+  metaOgTitle: { type: String },
+  metaXTitle: { type: String },
+  metaXDescription: { type: String },
+  commentShowStatus: { type: Boolean, default: true },
+  status: { type: String, enum: ['draft', 'published', 'archived'], default: 'draft' },
+  publishedDateTime: { type: Date },
+  faq: { type: String },
+  bgColor: { type: String },
+  bgColorStatus: { type: Boolean, default: false },
+  createdDate: { type: Date, default: Date.now },
+  modifiedDate: { type: Date, default: Date.now }
 }, {
-  timestamps: { 
-    createdAt: 'created_date',
-    updatedAt: 'modified_date'
-  }
+  timestamps: { createdAt: 'createdDate', updatedAt: 'modifiedDate' }
 });
 
-// Generate slug before saving
 blogSchema.pre('save', function(next) {
   if (this.isModified('title')) {
-    // Create base slug from title
-    let baseSlug = slugify(this.title, { 
-      lower: true,
-      strict: true,
-      trim: true
-    });
-    
-    // Add timestamp to ensure uniqueness
+    const baseSlug = slugify(this.title, { lower: true, strict: true, trim: true });
     this.slug = `${baseSlug}-${Date.now().toString().slice(-4)}`;
   }
   next();
 });
 
-// Index for search functionality
-blogSchema.index({ 
-  title: 'text', 
-  content: 'text',
-  excerpt: 'text'
+blogSchema.index({
+  title: 'text',
+  description: 'text',
+  shortDescription: 'text'
 });
 
 const Blog = mongoose.models.Blog || mongoose.model('Blog', blogSchema);
-
 export default Blog;


### PR DESCRIPTION
## Summary
- extend `Blog` model with more metadata fields
- support variable image sizes in `uploadBlogImage`
- update blog creation and update actions
- update API routes for new blog fields
- overhaul blog add/edit forms with new fields and shadcn selects

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68523f146470832884fba3d56cca095c