### PR TITLE
Add basic blog management

### DIFF
--- a/app/actions/blogs.js
+++ b/app/actions/blogs.js
@@ -1,0 +1,91 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import Blog from '@/app/models/Blog';
+import connectDB from '@/app/lib/db';
+import { uploadBlogImage } from '@/app/middleware/imageUpload';
+
+export async function createBlog(formData) {
+  try {
+    await connectDB();
+    const title = formData.get('title')?.trim();
+    const content = formData.get('content')?.trim();
+    const excerpt = formData.get('excerpt')?.trim();
+    const author = formData.get('author');
+    const categories = formData.getAll('categories');
+    const tags = formData.get('tags')?.split(',').map(t => t.trim()).filter(Boolean) || [];
+    const meta_title = formData.get('meta_title')?.trim();
+    const meta_description = formData.get('meta_description')?.trim();
+    const status = formData.get('status') || 'draft';
+    const imageFile = formData.get('featured_image');
+
+    if (!title || !content || !excerpt || !author || !imageFile) {
+      return { success: false, error: 'Missing required fields' };
+    }
+
+    const uploadResult = await uploadBlogImage(imageFile);
+    if (!uploadResult.success) {
+      return { success: false, error: uploadResult.error };
+    }
+
+    const blog = await Blog.create({
+      title,
+      content,
+      excerpt,
+      author,
+      categories,
+      tags,
+      featured_image: uploadResult.filename,
+      meta_title,
+      meta_description,
+      status,
+    });
+
+    revalidatePath('/admin/blogs');
+    const res = blog.toObject();
+    res._id = res._id.toString();
+    return { success: true, data: res };
+  } catch (error) {
+    console.error('Blog creation error:', error);
+    return { success: false, error: error.message || 'Failed to create blog' };
+  }
+}
+
+export async function updateBlog(id, formData) {
+  try {
+    await connectDB();
+    const blog = await Blog.findById(id);
+    if (!blog) return { success: false, error: 'Blog not found' };
+
+    const fields = ['title','content','excerpt','meta_title','meta_description','status'];
+    fields.forEach(f => {
+      const val = formData.get(f);
+      if (val !== null) blog[f] = val.trim();
+    });
+    const author = formData.get('author');
+    if (author) blog.author = author;
+    const categories = formData.getAll('categories');
+    if (categories.length) blog.categories = categories;
+    const tags = formData.get('tags');
+    if (tags !== null) blog.tags = tags.split(',').map(t => t.trim()).filter(Boolean);
+    const imageFile = formData.get('featured_image');
+    if (imageFile && typeof imageFile !== 'string') {
+      const uploadResult = await uploadBlogImage(imageFile);
+      if (!uploadResult.success) {
+        return { success: false, error: uploadResult.error };
+      }
+      blog.featured_image = uploadResult.filename;
+    }
+
+    blog.modified_date = new Date();
+    await blog.save();
+    revalidatePath('/admin/blogs');
+    revalidatePath(`/admin/blogs/${id}`);
+    const updated = blog.toObject();
+    updated._id = updated._id.toString();
+    return { success: true, data: updated };
+  } catch (error) {
+    console.error('Blog update error:', error);
+    return { success: false, error: error.message || 'Failed to update blog' };
+  }
+}

--- a/app/admin/blogs/[id]/edit/EditBlogForm.jsx
+++ b/app/admin/blogs/[id]/edit/EditBlogForm.jsx
@@ -1,0 +1,131 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { updateBlog } from "@/app/actions/blogs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import ImageCropperInput from "@/components/image-cropper-input";
+import { Button } from "@/components/ui/button";
+
+const blogFormSchema = z.object({
+  title: z.string().min(2).max(200),
+  excerpt: z.string().min(10).max(500),
+  content: z.string().min(10),
+  featured_image: z.any().optional(),
+});
+
+export default function EditBlogForm({ blog }) {
+  const form = useForm({
+    resolver: zodResolver(blogFormSchema),
+    defaultValues: {
+      title: blog.title || "",
+      excerpt: blog.excerpt || "",
+      content: blog.content || "",
+    },
+  });
+
+  async function onSubmit(data) {
+    const formData = new FormData();
+    formData.append('title', data.title.trim());
+    formData.append('excerpt', data.excerpt.trim());
+    formData.append('content', data.content.trim());
+    if (data.featured_image?.[0]) {
+      formData.append('featured_image', data.featured_image[0]);
+    }
+    const result = await updateBlog(blog._id, formData);
+    if (result.success) {
+      toast.success("Blog updated");
+    } else {
+      toast.error(result.error || "Failed to update blog");
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Edit Blog</CardTitle>
+        <CardDescription>Update blog details.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="excerpt"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Excerpt</FormLabel>
+                  <FormControl>
+                    <Textarea className="min-h-[80px]" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="content"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Content</FormLabel>
+                  <FormControl>
+                    <Textarea className="min-h-[120px]" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="featured_image"
+              render={({ field: { onChange, value } }) => (
+                <FormItem>
+                  <FormLabel>Featured Image</FormLabel>
+                  <FormControl>
+                    <ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end gap-4">
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting ? "Updating..." : "Update Blog"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -1,0 +1,28 @@
+import EditBlogForm from "./EditBlogForm";
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+export default async function Page({ params }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/${params.id}`, { cache: 'no-store' });
+  const json = await res.json();
+  const blog = json?.data;
+  if (!blog) {
+    return <div className="p-4">Blog not found</div>;
+  }
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="w-full p-4">
+        <EditBlogForm blog={blog} />
+      </div>
+    </>
+  );
+}

--- a/app/admin/blogs/[id]/page.jsx
+++ b/app/admin/blogs/[id]/page.jsx
@@ -1,0 +1,44 @@
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default async function Page({ params }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/${params.id}`, { cache: 'no-store' });
+  const json = await res.json();
+  const blog = json?.data;
+  if (!blog) {
+    return <div className="p-4">Blog not found</div>;
+  }
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="w-full p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>{blog.title}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p><strong>Status:</strong> {blog.status}</p>
+            <p><strong>Excerpt:</strong> {blog.excerpt}</p>
+            <p><strong>Content:</strong></p>
+            <div className="whitespace-pre-wrap">{blog.content}</div>
+            <p><strong>Created:</strong> {new Date(blog.created_date).toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <div className="mt-4 flex gap-2">
+          <Link href={`/admin/blogs/${blog._id}/edit`}><Button type="button">Edit</Button></Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -1,0 +1,149 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { toast } from "sonner";
+import { createBlog } from "@/app/actions/blogs";
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import ImageCropperInput from "@/components/image-cropper-input";
+import { Button } from "@/components/ui/button";
+
+const blogFormSchema = z.object({
+  title: z.string().min(2).max(200),
+  excerpt: z.string().min(10).max(500),
+  content: z.string().min(10),
+  featured_image: z.any().refine((file) => file?.length === 1, "Image required"),
+});
+
+export default function Page() {
+  const form = useForm({
+    resolver: zodResolver(blogFormSchema),
+    defaultValues: {
+      title: "",
+      excerpt: "",
+      content: "",
+    },
+  });
+
+  async function onSubmit(data) {
+    const formData = new FormData();
+    formData.append('title', data.title.trim());
+    formData.append('excerpt', data.excerpt.trim());
+    formData.append('content', data.content.trim());
+    if (data.featured_image?.[0]) {
+      formData.append('featured_image', data.featured_image[0]);
+    }
+    const result = await createBlog(formData);
+    if (result.success) {
+      toast.success("Blog created");
+      form.reset();
+    } else {
+      toast.error(result.error || "Failed to create blog");
+    }
+  }
+
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="w-full p-4">
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Add New Blog</CardTitle>
+              <CardDescription>Fill in the blog details below.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+                  <FormField
+                    control={form.control}
+                    name="title"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Title</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="excerpt"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Excerpt</FormLabel>
+                        <FormControl>
+                          <Textarea className="min-h-[80px]" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="content"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Content</FormLabel>
+                        <FormControl>
+                          <Textarea className="min-h-[120px]" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="featured_image"
+                    render={({ field: { onChange, value } }) => (
+                      <FormItem>
+                        <FormLabel>Featured Image</FormLabel>
+                        <FormControl>
+                          <ImageCropperInput aspectRatio={1080/617} value={value} onChange={onChange} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <div className="flex justify-end gap-4">
+                    <Button type="submit" disabled={form.formState.isSubmitting}>
+                      {form.formState.isSubmitting ? "Creating..." : "Create Blog"}
+                    </Button>
+                  </div>
+                </form>
+              </Form>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/admin/blogs/page.jsx
+++ b/app/admin/blogs/page.jsx
@@ -1,0 +1,32 @@
+import { BlogTable } from "@/components/blogTable";
+import { DynamicBreadcrumb } from "@/components/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs`, { cache: 'no-store' });
+  const json = await res.json();
+  const blogs = Array.isArray(json?.data) ? json.data : [];
+  const data = blogs.map(b => ({
+    id: b._id,
+    title: b.title,
+    status: b.status,
+    created_date: b.created_date,
+  }));
+
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <DynamicBreadcrumb />
+        </div>
+      </header>
+      <Separator />
+      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+        <BlogTable data={data} />
+      </div>
+    </>
+  );
+}

--- a/app/api/v1/admin/blogs/[id]/route.js
+++ b/app/api/v1/admin/blogs/[id]/route.js
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import mongoose from 'mongoose';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+import { extractToken, verifyToken } from '@/app/lib/auth';
+import { uploadBlogImage } from '@/app/middleware/imageUpload';
+
+export async function GET(req, { params }) {
+  try {
+    await connectDB();
+    const id = params.id;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid blog ID' }, { status: 400 });
+    }
+    const blog = await Blog.findById(id).lean();
+    if (!blog) {
+      return NextResponse.json({ success: false, error: 'Blog not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: blog });
+  } catch (error) {
+    console.error('Error fetching blog:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching blog' }, { status: 500 });
+  }
+}
+
+export async function PUT(req, { params }) {
+  try {
+    const token = extractToken(req.headers);
+    if (!token) return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+
+    await connectDB();
+    const id = params.id;
+    if (!mongoose.Types.ObjectId.isValid(id)) return NextResponse.json({ success: false, error: 'Invalid blog ID' }, { status: 400 });
+    const blog = await Blog.findById(id);
+    if (!blog) return NextResponse.json({ success: false, error: 'Blog not found' }, { status: 404 });
+
+    const formData = await req.formData();
+    const fields = ['title', 'content', 'excerpt', 'meta_title', 'meta_description', 'status'];
+    fields.forEach(f => {
+      const val = formData.get(f);
+      if (val !== null) blog[f] = val.trim();
+    });
+    const author = formData.get('author');
+    if (author) blog.author = author;
+    const categories = formData.getAll('categories');
+    if (categories.length) blog.categories = categories;
+    const tags = formData.get('tags');
+    if (tags !== null) blog.tags = tags.split(',').map(t => t.trim()).filter(Boolean);
+    const imageFile = formData.get('featured_image');
+    if (imageFile && typeof imageFile !== 'string') {
+      const up = await uploadBlogImage(imageFile);
+      if (!up.success) return NextResponse.json({ success: false, error: up.error }, { status: 400 });
+      blog.featured_image = up.filename;
+    }
+    blog.modified_date = new Date();
+    await blog.save();
+    return NextResponse.json({ success: true, data: blog });
+  } catch (error) {
+    console.error('Error updating blog:', error);
+    return NextResponse.json({ success: false, error: 'Error updating blog' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req, { params }) {
+  try {
+    const token = extractToken(req.headers);
+    if (!token) return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+
+    await connectDB();
+    const id = params.id;
+    if (!mongoose.Types.ObjectId.isValid(id)) return NextResponse.json({ success: false, error: 'Invalid blog ID' }, { status: 400 });
+    await Blog.findByIdAndDelete(id);
+    return NextResponse.json({ success: true, message: 'Blog deleted' });
+  } catch (error) {
+    console.error('Error deleting blog:', error);
+    return NextResponse.json({ success: false, error: 'Error deleting blog' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/blogs/route.js
+++ b/app/api/v1/admin/blogs/route.js
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+import Fuse from 'fuse.js';
+import { extractToken, verifyToken } from '@/app/lib/auth';
+import { uploadBlogImage } from '@/app/middleware/imageUpload';
+
+export async function GET(req) {
+  try {
+    await connectDB();
+    const { searchParams } = new URL(req.url);
+    const search = searchParams.get('search') || '';
+    const page = parseInt(searchParams.get('page')) || 1;
+    const limit = parseInt(searchParams.get('limit')) || 10;
+    const skip = (page - 1) * limit;
+
+    let blogs = await Blog.find().sort({ created_date: -1 }).lean();
+    if (search) {
+      const fuse = new Fuse(blogs, { keys: ['title', 'excerpt', 'content'], threshold: 0.3 });
+      blogs = fuse.search(search).map(res => res.item);
+    }
+    const total = blogs.length;
+    const data = blogs.slice(skip, skip + limit);
+
+    return NextResponse.json({ success: true, data, pagination: { total, page, limit, pages: Math.ceil(total / limit) } });
+  } catch (error) {
+    console.error('Error fetching blogs:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching blogs' }, { status: 500 });
+  }
+}
+
+export async function POST(req) {
+  try {
+    const token = extractToken(req.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+    const formData = await req.formData();
+    const title = formData.get('title')?.trim();
+    const content = formData.get('content')?.trim();
+    const excerpt = formData.get('excerpt')?.trim();
+    const author = formData.get('author');
+    const categories = formData.getAll('categories');
+    const tags = formData.get('tags')?.split(',').map(t => t.trim()).filter(Boolean) || [];
+    const meta_title = formData.get('meta_title')?.trim();
+    const meta_description = formData.get('meta_description')?.trim();
+    const status = formData.get('status') || 'draft';
+    const imageFile = formData.get('featured_image');
+
+    if (!title || !content || !excerpt || !author || !imageFile) {
+      return NextResponse.json({ success: false, error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const imageRes = await uploadBlogImage(imageFile);
+    if (!imageRes.success) {
+      return NextResponse.json({ success: false, error: imageRes.error }, { status: 400 });
+    }
+
+    const blog = await Blog.create({
+      title,
+      content,
+      excerpt,
+      author,
+      categories,
+      tags,
+      featured_image: imageRes.filename,
+      meta_title,
+      meta_description,
+      status,
+    });
+
+    return NextResponse.json({ success: true, data: blog }, { status: 201 });
+  } catch (error) {
+    console.error('Error creating blog:', error);
+    return NextResponse.json({ success: false, error: 'Error creating blog' }, { status: 500 });
+  }
+}

--- a/app/middleware/imageUpload.js
+++ b/app/middleware/imageUpload.js
@@ -110,5 +110,46 @@ export async function uploadAuthorImage(file) {
   }
 }
 
+// Upload and process blog image
+export async function uploadBlogImage(file) {
+  try {
+    if (!file) {
+      return {
+        success: false,
+        error: 'Please provide an image file',
+      };
+    }
+
+    const buffer = await file.arrayBuffer();
+    const fileType = await validateImageType(Buffer.from(buffer));
+    if (!fileType.success) {
+      return fileType;
+    }
+
+    await fs.mkdir(UPLOAD_DIRS.blogs, { recursive: true });
+    const filename = `blog-${Date.now()}.webp`;
+    const filepath = path.join(UPLOAD_DIRS.blogs, filename);
+
+    await sharp(Buffer.from(buffer))
+      .resize(1080, 617, {
+        fit: 'cover',
+        position: 'center',
+      })
+      .webp({ quality: 80 })
+      .toFile(filepath);
+
+    return {
+      success: true,
+      filename,
+    };
+  } catch (error) {
+    console.error('Error uploading blog image:', error);
+    return {
+      success: false,
+      error: 'Error processing image',
+    };
+  }
+}
+
 // Call initializeUploadDirs when the module loads
 initializeUploadDirs();

--- a/components/blogTable.jsx
+++ b/components/blogTable.jsx
@@ -1,0 +1,188 @@
+"use client";
+import * as React from "react";
+import {
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowUpDown, ChevronDown, MoreHorizontal, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import TokenFromCookie from "@/helpers/tokenFromCookie";
+
+function BlogActions({ blog }) {
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    try {
+      const token = TokenFromCookie();
+      const res = await fetch(`/api/v1/admin/blogs/${blog.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success('Blog deleted');
+        router.refresh();
+      } else {
+        toast.error(data.error || 'Failed to delete blog');
+      }
+    } catch (error) {
+      toast.error('Failed to delete blog');
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-8 w-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem asChild>
+          <Link href={`/admin/blogs/${blog.id}/edit`}>Edit</Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleDelete}>Delete</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export const columns = [
+  {
+    accessorKey: "title",
+    header: ({ column }) => (
+      <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>Title <ArrowUpDown className="ml-2 h-4 w-4" /></Button>
+    ),
+    cell: ({ row }) => (
+      <Link href={`/admin/blogs/${row.original.id}`} className="hover:underline font-medium">
+        {row.getValue("title")}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => <span className="capitalize">{row.getValue("status")}</span>,
+  },
+  {
+    accessorKey: "created_date",
+    header: ({ column }) => (
+      <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>Created <ArrowUpDown className="ml-2 h-4 w-4" /></Button>
+    ),
+    cell: ({ row }) => {
+      const date = new Date(row.getValue("created_date"));
+      return <span>{date.toLocaleString()}</span>;
+    },
+  },
+  {
+    id: "actions",
+    enableHiding: false,
+    cell: ({ row }) => <BlogActions blog={row.original} />,
+  },
+];
+
+export function BlogTable({ data }) {
+  const [sorting, setSorting] = React.useState([]);
+  const [rowSelection, setRowSelection] = React.useState({});
+  const [columnVisibility, setColumnVisibility] = React.useState({});
+
+  const table = useReactTable({
+    data,
+    columns,
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    state: {
+      sorting,
+      columnVisibility,
+      rowSelection,
+    },
+  });
+
+  return (
+    <div className="w-full">
+      <div className="flex gap-3 items-center py-4">
+        <Input
+          placeholder="Filter title..."
+          value={table.getColumn("title")?.getFilterValue() ?? ""}
+          onChange={(event) => table.getColumn("title")?.setFilterValue(event.target.value)}
+          className="max-w-sm"
+        />
+        <Button asChild className="ml-auto">
+          <Link href="/admin/blogs/add"><Plus /> Add Blog</Link>
+        </Button>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button variant="outline" size="sm" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+          Previous
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create blog API endpoints
- add image upload handler for blogs
- implement server actions for blog create/update
- add blog management pages with table, add, edit forms
- provide frontend components for blog table

## Testing
- `npm install --ignore-scripts`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_68525cb963908328a80ba50f3f79f3d1