### PR TITLE
Add blog APIs

### DIFF
--- a/app/api/v1/admin/blogs/[id]/route.js
+++ b/app/api/v1/admin/blogs/[id]/route.js
@@ -1,0 +1,226 @@
+import { NextResponse } from 'next/server';
+import mongoose from 'mongoose';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+import { uploadBlogImage } from '@/app/middleware/imageUpload';
+import slugify from 'slugify';
+
+export async function GET(request, context) {
+  try {
+    await connectDB();
+
+    const id = context.params.id;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid blog ID' }, { status: 400 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const showDeleted = searchParams.get('deleted') === 'true';
+
+    const query = { _id: id };
+    if (showDeleted) {
+      query.showDeleted = true;
+    }
+
+    const blog = await Blog.findOne(query).populate('author').populate('category');
+
+    if (!blog) {
+      return NextResponse.json({ success: false, error: 'Blog not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true, data: blog });
+  } catch (error) {
+    console.error('Error fetching blog:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching blog' }, { status: 500 });
+  }
+}
+
+export async function PUT(request, context) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+
+    const id = context.params.id;
+    if (!id || !mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid blog ID' }, { status: 400 });
+    }
+
+    const formData = await request.formData();
+    if (!formData) {
+      return NextResponse.json({ success: false, error: 'No form data provided' }, { status: 400 });
+    }
+
+    const blog = await Blog.findById(id);
+    if (!blog) {
+      return NextResponse.json({ success: false, error: 'Blog not found' }, { status: 404 });
+    }
+
+    const newSlug = formData.get('slug');
+    if (newSlug) {
+      const slugified = slugify(newSlug, { lower: true, strict: true, trim: true });
+      if (slugified !== blog.slug) {
+        const existingSlug = await Blog.findOne({ slug: slugified, _id: { $ne: id } });
+        if (existingSlug) {
+          return NextResponse.json({ success: false, error: 'Slug already exists' }, { status: 400 });
+        }
+        blog.slug = slugified;
+      }
+    }
+
+    const statusValue = Number(formData.get('status'));
+    if ([1, 2, 3].includes(statusValue)) {
+      blog.status = statusValue;
+    }
+
+    const bannerFile = formData.get('banner');
+    if (bannerFile) {
+      const res = await uploadBlogImage(bannerFile, 'banner');
+      if (!res.success) {
+        return NextResponse.json({ success: false, error: res.error }, { status: 400 });
+      }
+      blog.banner = res.filename;
+    }
+
+    const thumbnailFile = formData.get('thumbnail');
+    if (thumbnailFile) {
+      const res = await uploadBlogImage(thumbnailFile, 'thumbnail');
+      if (!res.success) {
+        return NextResponse.json({ success: false, error: res.error }, { status: 400 });
+      }
+      blog.thumbnail = res.filename;
+    }
+
+    const xImgFile = formData.get('xImage');
+    if (xImgFile) {
+      const res = await uploadBlogImage(xImgFile, 'xImage');
+      if (!res.success) {
+        return NextResponse.json({ success: false, error: res.error }, { status: 400 });
+      }
+      blog.x_image = res.filename;
+    }
+
+    const ogImgFile = formData.get('ogImage');
+    if (ogImgFile) {
+      const res = await uploadBlogImage(ogImgFile, 'ogImage');
+      if (!res.success) {
+        return NextResponse.json({ success: false, error: res.error }, { status: 400 });
+      }
+      blog.og_image = res.filename;
+    }
+
+    const metaKeywordString = formData.get('metaKeyword');
+    if (metaKeywordString !== null) {
+      blog.meta_keyword = metaKeywordString
+        .split(',')
+        .map((k) => k.trim())
+        .filter((k) => k);
+    }
+
+    const fields = {
+      category: 'category',
+      title: 'title',
+      authorId: 'author',
+      blogWrittenDate: 'blog_written_date',
+      shortDescription: 'short_description',
+      description: 'description',
+      imageAlt: 'image_alt',
+      xImageAlt: 'x_image_alt',
+      ogImageAlt: 'og_image_alt',
+      metaTitle: 'meta_title',
+      metaDescription: 'meta_description',
+      metaOgTitle: 'meta_og_title',
+      metaOgDescription: 'meta_og_description',
+      metaXTitle: 'meta_x_title',
+      metaXDescription: 'meta_x_description',
+      commentShowStatus: 'comment_show_status',
+      publishedDateTime: 'published_date_time',
+      bgColorStatus: 'bg_color_status',
+      bgColor: 'bg_color'
+    };
+
+    for (const [formField, modelField] of Object.entries(fields)) {
+      const val = formData.get(formField);
+      if (val !== null) {
+        if (modelField.endsWith('_date') || modelField.endsWith('_time')) {
+          blog[modelField] = val ? new Date(val) : null;
+        } else if (modelField === 'comment_show_status' || modelField === 'bg_color_status') {
+          blog[modelField] = val === 'true';
+        } else {
+          blog[modelField] = val;
+        }
+      }
+    }
+
+    await blog.save();
+
+    return NextResponse.json({ success: true, data: blog });
+  } catch (error) {
+    console.error('Error updating blog:', error);
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map((err) => err.message);
+      return NextResponse.json({ success: false, error: messages.join(', ') }, { status: 400 });
+    }
+    return NextResponse.json({ success: false, error: 'Error updating blog' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, context) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+    const id = context.params.id;
+    if (!id || !mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid blog ID' }, { status: 400 });
+    }
+    const { searchParams } = new URL(request.url);
+    const force = searchParams.get('force') === 'true';
+
+    const blog = await Blog.findOne({ _id: id }, null, { showDeleted: true });
+    if (!blog) {
+      return NextResponse.json({ success: false, error: 'Blog not found' }, { status: 404 });
+    }
+
+    if (blog.status !== 1 && !force) {
+      return NextResponse.json(
+        { success: false, error: 'Published or archived blogs cannot be deleted' },
+        { status: 400 }
+      );
+    }
+
+    if (force) {
+      await Blog.findByIdAndDelete(id, { showDeleted: true });
+      return NextResponse.json({ success: true, message: 'Blog has been permanently deleted' });
+    }
+
+    if (blog.deleted_at) {
+      return NextResponse.json({ success: true, message: 'Blog is already soft deleted', data: blog });
+    }
+
+    blog.deleted_at = new Date();
+    await blog.save();
+    return NextResponse.json({ success: true, message: 'Blog has been soft deleted', data: blog });
+  } catch (error) {
+    console.error('Error deleting blog:', error);
+    return NextResponse.json({ success: false, error: 'Error deleting blog' }, { status: 500 });
+  }
+}
+

--- a/app/api/v1/admin/blogs/authors/[id]/route.js
+++ b/app/api/v1/admin/blogs/authors/[id]/route.js
@@ -39,7 +39,7 @@ export async function GET(request, context) {
     }
 
     // Get blog count
-    const blogCount = await Blog.countDocuments({ author: id, status: 'published' });
+    const blogCount = await Blog.countDocuments({ author: id, status: 2 });
     author.blog_count = blogCount;
     await author.save();
 
@@ -153,7 +153,7 @@ export async function PUT(request, context) {
     );
 
     // Get current blog count
-    const blogCount = await Blog.countDocuments({ author: id, status: 'published' });
+    const blogCount = await Blog.countDocuments({ author: id, status: 2 });
     updatedAuthor.blog_count = blogCount;
     await updatedAuthor.save();
 

--- a/app/api/v1/admin/blogs/authors/route.js
+++ b/app/api/v1/admin/blogs/authors/route.js
@@ -81,7 +81,7 @@ export async function GET(req) {
 
     // Update blog counts for all authors
     const authorsWithCounts = await Promise.all(authors.map(async (author) => {
-      const blogCount = await Blog.countDocuments({ author: author._id, status: 'published' });
+      const blogCount = await Blog.countDocuments({ author: author._id, status: 2 });
       return {
         ...author,
         blog_count: blogCount

--- a/app/api/v1/admin/blogs/categories/[id]/route.js
+++ b/app/api/v1/admin/blogs/categories/[id]/route.js
@@ -26,7 +26,7 @@ export async function GET(request, context) {
       return NextResponse.json({ success: false, error: 'Category not found' }, { status: 404 });
     }
 
-    const blogCount = await Blog.countDocuments({ categories: id, status: 'published' });
+    const blogCount = await Blog.countDocuments({ categories: id, status: 2 });
     category.blog_count = blogCount;
     await category.save();
 
@@ -87,7 +87,7 @@ export async function PUT(request, context) {
     category.modified_date = new Date();
     await category.save();
 
-    const blogCount = await Blog.countDocuments({ categories: id, status: 'published' });
+    const blogCount = await Blog.countDocuments({ categories: id, status: 2 });
     category.blog_count = blogCount;
     await category.save();
 

--- a/app/api/v1/admin/blogs/categories/route.js
+++ b/app/api/v1/admin/blogs/categories/route.js
@@ -60,7 +60,7 @@ export async function GET(req) {
     const categories = allCategories.slice(skip, skip + limit);
 
     const categoriesWithCounts = await Promise.all(categories.map(async (cat) => {
-      const blogCount = await Blog.countDocuments({ categories: cat._id, status: 'published' });
+      const blogCount = await Blog.countDocuments({ categories: cat._id, status: 2 });
       return { ...cat, blog_count: blogCount };
     }));
 

--- a/app/api/v1/admin/blogs/route.js
+++ b/app/api/v1/admin/blogs/route.js
@@ -1,0 +1,185 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+import Fuse from 'fuse.js';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+import { uploadBlogImage } from '@/app/middleware/imageUpload';
+import slugify from 'slugify';
+
+export async function GET(req) {
+  try {
+    await connectDB();
+    const { searchParams } = new URL(req.url);
+
+    const search = searchParams.get('search');
+    const showDeleted = searchParams.get('deleted') === 'true';
+    const status = searchParams.get('status');
+    const sortBy = searchParams.get('sortBy') || 'created_date';
+    const sortOrder = parseInt(searchParams.get('sortOrder')) || -1;
+    const page = parseInt(searchParams.get('page')) || 1;
+    const limit = parseInt(searchParams.get('limit')) || 10;
+    const skip = (page - 1) * limit;
+
+    const baseQuery = {};
+    if (!showDeleted) {
+      baseQuery.deleted_at = null;
+    }
+    if (status) {
+      const numericStatus = parseInt(status, 10);
+      if (![1, 2, 3].includes(numericStatus)) {
+        return NextResponse.json(
+          { success: false, error: 'Invalid status value. Must be 1 (Draft), 2 (Published), or 3 (Archived)' },
+          { status: 400 }
+        );
+      }
+      baseQuery.status = numericStatus;
+    }
+
+    let allBlogs = await Blog.find(baseQuery)
+      .populate('author')
+      .populate('category')
+      .select('-__v')
+      .lean();
+
+    if (search) {
+      const fuseOptions = {
+        keys: ['title', 'short_description', 'slug'],
+        threshold: 0.3,
+        includeScore: true
+      };
+      const fuse = new Fuse(allBlogs, fuseOptions);
+      const searchResults = fuse.search(search);
+      allBlogs = searchResults.map((r) => r.item);
+    }
+
+    const total = allBlogs.length;
+
+    if (sortBy) {
+      allBlogs.sort((a, b) => {
+        const aValue = a[sortBy];
+        const bValue = b[sortBy];
+        return sortOrder * (aValue > bValue ? 1 : -1);
+      });
+    }
+
+    const blogs = allBlogs.slice(skip, skip + limit);
+
+    return NextResponse.json({
+      success: true,
+      data: blogs,
+      pagination: {
+        total,
+        page,
+        limit,
+        pages: Math.ceil(total / limit)
+      }
+    });
+  } catch (error) {
+    console.error('Error fetching blogs:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching blogs' }, { status: 500 });
+  }
+}
+
+export async function POST(req) {
+  try {
+    const token = extractToken(req.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+
+    const formData = await req.formData();
+
+    const slug = slugify(formData.get('slug') || '', { lower: true, strict: true, trim: true });
+
+    const existingSlug = await Blog.findOne({ slug });
+    if (existingSlug) {
+      return NextResponse.json({ success: false, error: 'Slug already exists' }, { status: 400 });
+    }
+
+    const statusValue = Number(formData.get('status')) || 1;
+    if (![1, 2, 3].includes(statusValue)) {
+      return NextResponse.json(
+        { success: false, error: 'Status must be 1 (Draft), 2 (Published), or 3 (Archived)' },
+        { status: 400 }
+      );
+    }
+
+    const bannerFile = formData.get('banner');
+    const banner = bannerFile ? await uploadBlogImage(bannerFile, 'banner') : null;
+    if (bannerFile && !banner.success) {
+      return NextResponse.json({ success: false, error: banner.error }, { status: 400 });
+    }
+
+    const thumbnailFile = formData.get('thumbnail');
+    const thumbnail = thumbnailFile ? await uploadBlogImage(thumbnailFile, 'thumbnail') : null;
+    if (thumbnailFile && !thumbnail.success) {
+      return NextResponse.json({ success: false, error: thumbnail.error }, { status: 400 });
+    }
+
+    const xImgFile = formData.get('xImage');
+    const xImage = xImgFile ? await uploadBlogImage(xImgFile, 'xImage') : null;
+    if (xImgFile && !xImage.success) {
+      return NextResponse.json({ success: false, error: xImage.error }, { status: 400 });
+    }
+
+    const ogImgFile = formData.get('ogImage');
+    const ogImage = ogImgFile ? await uploadBlogImage(ogImgFile, 'ogImage') : null;
+    if (ogImgFile && !ogImage.success) {
+      return NextResponse.json({ success: false, error: ogImage.error }, { status: 400 });
+    }
+
+    const metaKeywordString = formData.get('metaKeyword') || '';
+    const metaKeyword = metaKeywordString
+      .split(',')
+      .map((k) => k.trim())
+      .filter((k) => k);
+
+    const blogData = {
+      category: formData.get('category'),
+      title: formData.get('title'),
+      author: formData.get('authorId'),
+      blog_written_date: formData.get('blogWrittenDate') ? new Date(formData.get('blogWrittenDate')) : null,
+      slug,
+      short_description: formData.get('shortDescription'),
+      description: formData.get('description'),
+      banner: banner?.filename,
+      thumbnail: thumbnail?.filename,
+      image_alt: formData.get('imageAlt'),
+      x_image: xImage?.filename,
+      x_image_alt: formData.get('xImageAlt'),
+      og_image: ogImage?.filename,
+      og_image_alt: formData.get('ogImageAlt'),
+      meta_title: formData.get('metaTitle'),
+      meta_keyword: metaKeyword,
+      meta_description: formData.get('metaDescription'),
+      meta_og_title: formData.get('metaOgTitle'),
+      meta_og_description: formData.get('metaOgDescription'),
+      meta_x_title: formData.get('metaXTitle'),
+      meta_x_description: formData.get('metaXDescription'),
+      comment_show_status: formData.get('commentShowStatus') === 'true',
+      status: statusValue,
+      published_date_time: formData.get('publishedDateTime') ? new Date(formData.get('publishedDateTime')) : null,
+      bg_color_status: formData.get('bgColorStatus') === 'true',
+      bg_color: formData.get('bgColor')
+    };
+
+    const blog = await Blog.create(blogData);
+
+    return NextResponse.json({ success: true, data: blog }, { status: 201 });
+  } catch (error) {
+    console.error('Error creating blog:', error);
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map((err) => err.message);
+      return NextResponse.json({ success: false, error: messages.join(', ') }, { status: 400 });
+    }
+    return NextResponse.json({ success: false, error: 'Error creating blog' }, { status: 500 });
+  }
+}
+

--- a/app/middleware/imageUpload.js
+++ b/app/middleware/imageUpload.js
@@ -110,5 +110,52 @@ export async function uploadAuthorImage(file) {
   }
 }
 
+// Upload and process blog image
+export async function uploadBlogImage(file, type = 'generic') {
+  try {
+    if (!file) {
+      return {
+        success: false,
+        error: 'Please provide an image file'
+      };
+    }
+
+    const buffer = await file.arrayBuffer();
+
+    const fileType = await validateImageType(Buffer.from(buffer));
+    if (!fileType.success) {
+      return fileType;
+    }
+
+    await fs.mkdir(UPLOAD_DIRS.blogs, { recursive: true });
+
+    const filename = `blog-${type}-${Date.now()}.webp`;
+    const filepath = path.join(UPLOAD_DIRS.blogs, filename);
+
+    let width = 1080;
+    let height = 617;
+    if (type === 'xImage' || type === 'ogImage') {
+      width = 1200;
+      height = 630;
+    }
+
+    await sharp(Buffer.from(buffer))
+      .resize(width, height, { fit: 'cover', position: 'center' })
+      .webp({ quality: 80 })
+      .toFile(filepath);
+
+    return {
+      success: true,
+      filename
+    };
+  } catch (error) {
+    console.error('Error uploading blog image:', error);
+    return {
+      success: false,
+      error: 'Error processing image'
+    };
+  }
+}
+
 // Call initializeUploadDirs when the module loads
 initializeUploadDirs();

--- a/app/models/Blog.js
+++ b/app/models/Blog.js
@@ -1,101 +1,138 @@
 import mongoose from 'mongoose';
 import slugify from 'slugify';
 
-const blogSchema = new mongoose.Schema({
-  title: {
-    type: String,
-    required: [true, 'Blog title is required'],
-    trim: true,
-    maxlength: [200, 'Title cannot be more than 200 characters'],
-    unique: true
+const blogSchema = new mongoose.Schema(
+  {
+    status: {
+      type: Number,
+      enum: [1, 2, 3], // 1=draft, 2=published, 3=archived
+      default: 1
+    },
+    deleted_at: {
+      type: Date,
+      default: null
+    },
+    category: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Category',
+      required: [true, 'Blog category is required']
+    },
+    title: {
+      type: String,
+      required: [true, 'Blog title is required'],
+      trim: true,
+      maxlength: [200, 'Title cannot be more than 200 characters'],
+      unique: true
+    },
+    author: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Author',
+      required: [true, 'Blog author is required']
+    },
+    blog_written_date: {
+      type: Date,
+      required: [true, 'Blog written date is required']
+    },
+    slug: {
+      type: String,
+      unique: true,
+      index: true,
+      required: true
+    },
+    short_description: {
+      type: String,
+      required: [true, 'Blog short description is required'],
+      maxlength: [500, 'Short description cannot be more than 500 characters']
+    },
+    description: {
+      type: String,
+      required: [true, 'Blog description is required']
+    },
+    banner: {
+      type: String,
+      required: [true, 'Banner image is required']
+    },
+    thumbnail: {
+      type: String,
+      required: [true, 'Thumbnail image is required']
+    },
+    image_alt: {
+      type: String
+    },
+    x_image: {
+      type: String
+    },
+    x_image_alt: {
+      type: String
+    },
+    og_image: {
+      type: String
+    },
+    og_image_alt: {
+      type: String
+    },
+    meta_title: {
+      type: String
+    },
+    meta_keyword: [String],
+    meta_description: {
+      type: String
+    },
+    meta_og_title: String,
+    meta_og_description: String,
+    meta_x_title: String,
+    meta_x_description: String,
+    comment_show_status: {
+      type: Boolean,
+      default: true
+    },
+    published_date_time: Date,
+    bg_color_status: {
+      type: Boolean,
+      default: false
+    },
+    bg_color: String,
+    created_date: {
+      type: Date,
+      default: Date.now
+    },
+    modified_date: {
+      type: Date,
+      default: Date.now
+    }
   },
-  slug: {
-    type: String,
-    unique: true,
-    index: true
-  },
-  content: {
-    type: String,
-    required: [true, 'Blog content is required']
-  },
-  excerpt: {
-    type: String,
-    required: [true, 'Blog excerpt is required'],
-    maxlength: [500, 'Excerpt cannot be more than 500 characters']
-  },
-  author: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Author',
-    required: [true, 'Blog author is required']
-  },
-  categories: [{
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Category'
-  }],
-  tags: [{
-    type: String,
-    trim: true
-  }],
-  featured_image: {
-    type: String,
-    required: [true, 'Featured image is required']
-  },
-  status: {
-    type: String,
-    enum: ['draft', 'published', 'archived'],
-    default: 'draft'
-  },
-  meta_title: {
-    type: String,
-    required: [true, 'Meta title is required'],
-    maxlength: [60, 'Meta title cannot be more than 60 characters']
-  },
-  meta_description: {
-    type: String,
-    required: [true, 'Meta description is required'],
-    maxlength: [160, 'Meta description cannot be more than 160 characters']
-  },
-  views: {
-    type: Number,
-    default: 0
-  },
-  created_date: {
-    type: Date,
-    default: Date.now
-  },
-  modified_date: {
-    type: Date,
-    default: Date.now
+  {
+    timestamps: {
+      createdAt: 'created_date',
+      updatedAt: 'modified_date'
+    }
   }
-}, {
-  timestamps: { 
-    createdAt: 'created_date',
-    updatedAt: 'modified_date'
-  }
-});
+);
 
-// Generate slug before saving
-blogSchema.pre('save', function(next) {
-  if (this.isModified('title')) {
-    // Create base slug from title
-    let baseSlug = slugify(this.title, { 
-      lower: true,
-      strict: true,
-      trim: true
+blogSchema.pre('validate', async function (next) {
+  if (this.isModified('slug')) {
+    this.slug = slugify(this.slug, { lower: true, strict: true, trim: true });
+
+    const existing = await mongoose.models.Blog.findOne({
+      slug: this.slug,
+      _id: { $ne: this._id }
     });
-    
-    // Add timestamp to ensure uniqueness
-    this.slug = `${baseSlug}-${Date.now().toString().slice(-4)}`;
+
+    if (existing) {
+      this.invalidate('slug', 'Slug must be unique');
+    }
   }
   next();
 });
 
-// Index for search functionality
-blogSchema.index({ 
-  title: 'text', 
-  content: 'text',
-  excerpt: 'text'
+blogSchema.pre(['find', 'findOne', 'countDocuments'], function () {
+  const showDeleted = this.getOptions().showDeleted;
+  if (!showDeleted && !this._conditions.deleted_at) {
+    this.where({ deleted_at: null });
+  }
 });
+
+blogSchema.index({ title: 'text', short_description: 'text', description: 'text' });
 
 const Blog = mongoose.models.Blog || mongoose.model('Blog', blogSchema);
 


### PR DESCRIPTION
## Summary
- extend Blog schema to support many fields
- add image upload helper for blog images
- implement admin APIs to manage blog posts
- adjust author and category API routes for numeric blog status

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685262e136c88328b0960fe646c3633e