### PR TITLE
Remove soft delete from blog API

### DIFF
--- a/app/api/v1/admin/blogs/route.js
+++ b/app/api/v1/admin/blogs/route.js
@@ -12,7 +12,6 @@ export async function GET(req) {
     const { searchParams } = new URL(req.url);
 
     const search = searchParams.get('search');
-    const showDeleted = searchParams.get('deleted') === 'true';
     const status = searchParams.get('status');
     const sortBy = searchParams.get('sortBy') || 'created_date';
     const sortOrder = parseInt(searchParams.get('sortOrder')) || -1;
@@ -21,9 +20,6 @@ export async function GET(req) {
     const skip = (page - 1) * limit;
 
     const baseQuery = {};
-    if (!showDeleted) {
-      baseQuery.deleted_at = null;
-    }
     if (status) {
       const numericStatus = parseInt(status, 10);
       if (![1, 2, 3].includes(numericStatus)) {
@@ -35,7 +31,7 @@ export async function GET(req) {
       baseQuery.status = numericStatus;
     }
 
-    let allBlogs = await Blog.find(baseQuery, null, { showDeleted })
+    let allBlogs = await Blog.find(baseQuery)
       .populate('author')
       .populate('category')
       .select('-__v')

--- a/app/models/Blog.js
+++ b/app/models/Blog.js
@@ -8,10 +8,6 @@ const blogSchema = new mongoose.Schema(
       enum: [1, 2, 3], // 1=draft, 2=published, 3=archived
       default: 1
     },
-    deleted_at: {
-      type: Date,
-      default: null
-    },
     category: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Category',
@@ -125,12 +121,6 @@ blogSchema.pre('validate', async function (next) {
   next();
 });
 
-blogSchema.pre(['find', 'findOne', 'countDocuments'], function () {
-  const showDeleted = this.getOptions().showDeleted;
-  if (!showDeleted && !this._conditions.deleted_at) {
-    this.where({ deleted_at: null });
-  }
-});
 
 blogSchema.index({ title: 'text', short_description: 'text', description: 'text' });
 


### PR DESCRIPTION
## Summary
- keep only permanent delete for blogs
- remove deleted_at field from Blog model
- clean up GET routes and DELETE logic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68527ff5e4648328b013d92a4bd39760