### PR TITLE
Disallow reverting blogs to draft

### DIFF
--- a/app/api/v1/admin/blogs/[id]/route.js
+++ b/app/api/v1/admin/blogs/[id]/route.js
@@ -75,6 +75,12 @@ export async function PUT(request, context) {
 
     const statusValue = Number(formData.get('status'));
     if ([1, 2, 3].includes(statusValue)) {
+      if (statusValue === 1 && blog.status !== 1) {
+        return NextResponse.json(
+          { success: false, error: 'Cannot revert to draft once published or archived' },
+          { status: 400 }
+        );
+      }
       blog.status = statusValue;
     }
 

--- a/components/blogTable.jsx
+++ b/components/blogTable.jsx
@@ -158,9 +158,11 @@ function BlogActions({ blog }) {
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>Change Status</DropdownMenuSubTrigger>
           <DropdownMenuSubContent>
-            <DropdownMenuItem onClick={() => handleStatusChange(1)}>
-              Draft
-            </DropdownMenuItem>
+            {blog.status === "draft" && (
+              <DropdownMenuItem onClick={() => handleStatusChange(1)}>
+                Draft
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={() => handleStatusChange(2)}>
               Published
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- prevent reverting a published or archived blog back to draft at the API level
- hide the **Draft** status action once a blog is no longer in draft status

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68528981217c8328ada8ea2e946127c3