### PR TITLE
Add CkEditor client component

### DIFF
--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -31,6 +31,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { DatePicker } from "@/components/ui/date-picker";
+import { CkEditor } from "@/components/CkEditor";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -300,7 +301,10 @@ export default function Page() {
                       <FormItem>
                         <FormLabel>Description</FormLabel>
                         <FormControl>
-                          <Textarea className="min-h-[120px]" {...field} />
+                          <CkEditor
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/components/CkEditor.jsx
+++ b/components/CkEditor.jsx
@@ -1,0 +1,22 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const CKEditorBase = dynamic(() => import('@ckeditor/ckeditor5-react').then(m => m.CKEditor), { ssr: false })
+const ClassicEditor = dynamic(() => import('@ckeditor/ckeditor5-build-classic'), { ssr: false })
+
+function CkEditor({ value, onChange, config = {}, ...props }) {
+  return (
+    <CKEditorBase
+      editor={ClassicEditor}
+      data={value}
+      onChange={(_, editor) => {
+        onChange?.(editor.getData())
+      }}
+      config={{ licenseKey: '', ...config }}
+      {...props}
+    />
+  )
+}
+
+export { CkEditor }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "swiper": "^11.2.8",
     "tailwind-merge": "^3.3.0",
     "zod": "^3.25.64",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "@ckeditor/ckeditor5-react": "^9.5.0",
+    "@ckeditor/ckeditor5-build-classic": "^44.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -70,7 +72,8 @@
     "postcss": "^8.5.4",
     "prettier": "^3.5.3",
     "tailwindcss": "^4.1.8",
-    "tw-animate-css": "^1.3.4"
+    "tw-animate-css": "^1.3.4",
+    "typescript": "^5.8.3"
   },
   "browserslist": [
     "defaults and supports es6-module",


### PR DESCRIPTION
## Summary
- create a `CkEditor` client component that dynamically loads CKEditor
- replace inline dynamic imports in blog add page with `CkEditor`
- add TypeScript as a dev dependency so ESLint runs

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852da8816d48328a372d5f911df1301