### PR TITLE
Implement draft auto-save system

### DIFF
--- a/app/api/v1/admin/blogs/draft/route.js
+++ b/app/api/v1/admin/blogs/draft/route.js
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import BlogDraft from '@/app/models/BlogDraft';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+async function auth(headers) {
+  const token = extractToken(headers);
+  if (!token) return { error: NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 }) };
+  const decoded = verifyToken(token);
+  if (!decoded || decoded.role !== 'admin') {
+    return { error: NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 }) };
+  }
+  return { decoded };
+}
+
+export async function POST(req) {
+  const a = await auth(req.headers);
+  if (a.error) return a.error;
+  try {
+    await connectDB();
+    const data = await req.json();
+    const draft = await BlogDraft.create(data);
+    return NextResponse.json({ success: true, data: draft }, { status: 201 });
+  } catch (err) {
+    console.error('Error creating draft:', err);
+    return NextResponse.json({ success: false, error: 'Error creating draft' }, { status: 500 });
+  }
+}
+
+export async function PUT(req) {
+  const a = await auth(req.headers);
+  if (a.error) return a.error;
+  try {
+    await connectDB();
+    const data = await req.json();
+    if (!data._id) {
+      return NextResponse.json({ success: false, error: 'Draft ID required' }, { status: 400 });
+    }
+    const draft = await BlogDraft.findByIdAndUpdate(data._id, data, { new: true, upsert: true });
+    return NextResponse.json({ success: true, data: draft });
+  } catch (err) {
+    console.error('Error updating draft:', err);
+    return NextResponse.json({ success: false, error: 'Error updating draft' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/blogs/publish/route.js
+++ b/app/api/v1/admin/blogs/publish/route.js
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+import BlogDraft from '@/app/models/BlogDraft';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+async function auth(headers) {
+  const token = extractToken(headers);
+  if (!token) return { error: NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 }) };
+  const decoded = verifyToken(token);
+  if (!decoded || decoded.role !== 'admin') {
+    return { error: NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 }) };
+  }
+  return { decoded };
+}
+
+export async function POST(req) {
+  const a = await auth(req.headers);
+  if (a.error) return a.error;
+  try {
+    await connectDB();
+    const { draftId } = await req.json();
+    if (!draftId) {
+      return NextResponse.json({ success: false, error: 'draftId is required' }, { status: 400 });
+    }
+    const draft = await BlogDraft.findById(draftId).lean();
+    if (!draft) {
+      return NextResponse.json({ success: false, error: 'Draft not found' }, { status: 404 });
+    }
+    const data = { ...draft };
+    delete data._id;
+    delete data.created_date;
+    delete data.modified_date;
+    let blog;
+    if (draft.blogId) {
+      blog = await Blog.findByIdAndUpdate(draft.blogId, data, { new: true });
+    } else {
+      blog = await Blog.create(data);
+    }
+    await BlogDraft.findByIdAndDelete(draftId);
+    return NextResponse.json({ success: true, data: blog });
+  } catch (err) {
+    console.error('Error publishing blog:', err);
+    return NextResponse.json({ success: false, error: 'Error publishing blog' }, { status: 500 });
+  }
+}

--- a/app/models/BlogDraft.js
+++ b/app/models/BlogDraft.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+const blogDraftSchema = new mongoose.Schema(
+  {
+    blogId: { type: mongoose.Schema.Types.ObjectId, ref: 'Blog', default: null }
+  },
+  {
+    strict: false,
+    timestamps: { createdAt: 'created_date', updatedAt: 'modified_date' }
+  }
+);
+
+const BlogDraft = mongoose.models.BlogDraft || mongoose.model('BlogDraft', blogDraftSchema);
+
+export default BlogDraft;


### PR DESCRIPTION
## Summary
- create `BlogDraft` model
- add `/draft` and `/publish` API endpoints
- implement auto-save of blog form data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546f3cccd48328ba8fb8f63a71dd37