### PR TITLE
Implement blog draft autosave

### DIFF
--- a/app/api/v1/admin/blogs/drafts/[id]/route.js
+++ b/app/api/v1/admin/blogs/drafts/[id]/route.js
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+import mongoose from 'mongoose';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function GET(request, { params }) {
+  try {
+    await connectDB();
+    const { id } = params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid draft ID' }, { status: 400 });
+    }
+    const blog = await Blog.findById(id);
+    if (!blog) {
+      return NextResponse.json({ success: false, error: 'Draft not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: blog });
+  } catch (error) {
+    console.error('Error fetching draft:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching draft' }, { status: 500 });
+  }
+}
+
+export async function PUT(request, { params }) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+    const { id } = params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid draft ID' }, { status: 400 });
+    }
+    const body = await request.json();
+    const blog = await Blog.findByIdAndUpdate(id, body, { new: true, runValidators: true });
+    if (!blog) {
+      return NextResponse.json({ success: false, error: 'Draft not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: blog });
+  } catch (error) {
+    console.error('Error updating draft:', error);
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map((err) => err.message);
+      return NextResponse.json({ success: false, error: messages.join(', ') }, { status: 400 });
+    }
+    return NextResponse.json({ success: false, error: 'Error updating draft' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+    const { id } = params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid draft ID' }, { status: 400 });
+    }
+    const blog = await Blog.findByIdAndDelete(id);
+    if (!blog) {
+      return NextResponse.json({ success: false, error: 'Draft not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, message: 'Draft deleted' });
+  } catch (error) {
+    console.error('Error deleting draft:', error);
+    return NextResponse.json({ success: false, error: 'Error deleting draft' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/blogs/drafts/latest/route.js
+++ b/app/api/v1/admin/blogs/drafts/latest/route.js
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+
+export async function GET() {
+  try {
+    await connectDB();
+    const draft = await Blog.findOne({ status: 1 }).sort({ modified_date: -1 });
+    return NextResponse.json({ success: true, data: draft });
+  } catch (error) {
+    console.error('Error fetching latest draft:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching draft' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/blogs/drafts/route.js
+++ b/app/api/v1/admin/blogs/drafts/route.js
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function POST(req) {
+  try {
+    const token = extractToken(req.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+    const body = await req.json();
+    const blog = await Blog.create({ status: 1, ...body });
+    return NextResponse.json({ success: true, data: blog }, { status: 201 });
+  } catch (error) {
+    console.error('Error creating draft:', error);
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map((err) => err.message);
+      return NextResponse.json({ success: false, error: messages.join(', ') }, { status: 400 });
+    }
+    return NextResponse.json({ success: false, error: 'Error creating draft' }, { status: 500 });
+  }
+}

--- a/app/models/Blog.js
+++ b/app/models/Blog.js
@@ -11,11 +11,11 @@ const blogSchema = new mongoose.Schema(
     category: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Category',
-      required: [true, 'Blog category is required']
+      required: [function() { return this.status !== 1; }, 'Blog category is required']
     },
     title: {
       type: String,
-      required: [true, 'Blog title is required'],
+      required: [function() { return this.status !== 1; }, 'Blog title is required'],
       trim: true,
       maxlength: [200, 'Title cannot be more than 200 characters'],
       unique: true
@@ -23,82 +23,82 @@ const blogSchema = new mongoose.Schema(
     author: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Author',
-      required: [true, 'Blog author is required']
+      required: [function() { return this.status !== 1; }, 'Blog author is required']
     },
     blog_written_date: {
       type: Date,
-      required: [true, 'Blog written date is required']
+      required: [function() { return this.status !== 1; }, 'Blog written date is required']
     },
     slug: {
       type: String,
       unique: true,
       index: true,
-      required: true
+      required: [function() { return this.status !== 1; }, 'Slug is required']
     },
     short_description: {
       type: String,
-      required: [true, 'Blog short description is required'],
+      required: [function() { return this.status !== 1; }, 'Blog short description is required'],
       maxlength: [500, 'Short description cannot be more than 500 characters']
     },
     description: {
       type: String,
-      required: [true, 'Blog description is required']
+      required: [function() { return this.status !== 1; }, 'Blog description is required']
     },
     banner: {
       type: String,
-      required: [true, 'Banner image is required']
+      required: [function() { return this.status !== 1; }, 'Banner image is required']
     },
     thumbnail: {
       type: String,
-      required: [true, 'Thumbnail image is required']
+      required: [function() { return this.status !== 1; }, 'Thumbnail image is required']
     },
     image_alt: {
       type: String,
-      required: [true, 'Image alt is required']
+      required: [function() { return this.status !== 1; }, 'Image alt is required']
     },
     x_image: {
       type: String,
-      required: [true, 'X image is required']
+      required: [function() { return this.status !== 1; }, 'X image is required']
     },
     x_image_alt: {
       type: String,
-      required: [true, 'X image alt is required']
+      required: [function() { return this.status !== 1; }, 'X image alt is required']
     },
     og_image: {
       type: String,
-      required: [true, 'OG image is required']
+      required: [function() { return this.status !== 1; }, 'OG image is required']
     },
     og_image_alt: {
       type: String,
-      required: [true, 'OG image alt is required']
+      required: [function() { return this.status !== 1; }, 'OG image alt is required']
     },
     meta_title: {
       type: String,
-      required: [true, 'Meta title is required'],
+      required: [function() { return this.status !== 1; }, 'Meta title is required'],
     },
     meta_keyword: {
       type: [String],
-      required: [true, 'Meta keyword is required'],
+      required: [function() { return this.status !== 1; }, 'Meta keyword is required'],
     },
     meta_description: {
       type: String,
-      required: [true, 'Meta description is required'],
+      required: [function() { return this.status !== 1; }, 'Meta description is required'],
     },
     meta_og_title: {
       type: String,
-      required: [true, 'Meta OG title is required'],
+      required: [function() { return this.status !== 1; }, 'Meta OG title is required'],
     },
     meta_og_description: {
       type: String,
-      required: [true, 'Meta OG description is required'],
+      required: [function() { return this.status !== 1; }, 'Meta OG description is required'],
     },
     meta_x_title:  {
       type: String,
-      required: [true, 'Meta X title is required'],
+      required: [function() { return this.status !== 1; }, 'Meta X title is required'],
     },
     meta_x_description: {
       type: String,
-      required: [true, 'Meta X description is required'],
+      required: [function() { return this.status !== 1; }, 'Meta X description is required'],
     },
     comment_show_status: {
       type: Boolean,


### PR DESCRIPTION
## Summary
- support draft blogs by skipping required validation when status is draft
- add API routes for creating, updating, and deleting draft blogs
- implement auto-save in admin add blog page
- allow fetching latest draft without relying on localStorage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854e4cff2748328866948e1956285c5