### PR TITLE
Add draft auto-save feature

### DIFF
--- a/hooks/useAutoSaveDraft.js
+++ b/hooks/useAutoSaveDraft.js
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Generic auto-save hook that triggers callback after user stops typing.
+ * @param {*} watchValue - value from form.watch()
+ * @param {Function} callback - function to run on save
+ * @param {number} delay - debounce delay in ms
+ */
+export default function useAutoSaveDraft(watchValue, callback, delay = 5000) {
+  const timeout = useRef(null);
+
+  useEffect(() => {
+    if (timeout.current) clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
+      callback(watchValue);
+    }, delay);
+
+    return () => {
+      if (timeout.current) clearTimeout(timeout.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watchValue]);
+}


### PR DESCRIPTION
## Summary
- introduce `useAutoSaveDraft` hook for delayed saving
- auto-save blog drafts after typing stops on the add page
- factor out form data builder and reuse in final submit

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854eaf14c708328bbc56c8374b3a29c