### PR TITLE
Add runtime redirection handling

### DIFF
--- a/app/api/v1/admin/redirections/[id]/route.js
+++ b/app/api/v1/admin/redirections/[id]/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import connectDB from '@/app/lib/db';
 import Redirection from '@/app/models/Redirection';
 import { redirectionSchema } from '@/app/lib/validations/redirection';
+import { clearRedirectionsCache } from '@/app/lib/redirections';
 
 // DELETE: Delete a redirection
 export async function DELETE(request, { params }) {
@@ -12,6 +13,7 @@ export async function DELETE(request, { params }) {
     if (!deleted) {
       return NextResponse.json({ success: false, error: 'Redirection not found' }, { status: 404 });
     }
+    clearRedirectionsCache();
     return NextResponse.json({ success: true, message: 'Redirection deleted successfully', data: deleted });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error deleting redirection' }, { status: 500 });
@@ -48,6 +50,7 @@ export async function PATCH(request, { params }) {
     if (!updated) {
       return NextResponse.json({ success: false, error: 'Redirection not found' }, { status: 404 });
     }
+    clearRedirectionsCache();
     return NextResponse.json({ success: true, message: 'Redirection updated successfully', data: updated });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error updating redirection' }, { status: 500 });

--- a/app/api/v1/admin/redirections/route.js
+++ b/app/api/v1/admin/redirections/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import connectDB from '@/app/lib/db';
 import Redirection from '@/app/models/Redirection';
 import { redirectionSchema } from '@/app/lib/validations/redirection';
+import { clearRedirectionsCache } from '@/app/lib/redirections';
 
 // GET: Get all redirections
 export async function GET() {
@@ -39,6 +40,7 @@ export async function POST(request) {
       return NextResponse.json({ success: false, error: 'Redirection from this URL already exists' }, { status: 400 });
     }
     const redirection = await Redirection.create(parsed.data);
+    clearRedirectionsCache();
     return NextResponse.json({ success: true, message: 'Redirection created successfully', data: redirection }, { status: 201 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error creating redirection' }, { status: 500 });

--- a/app/lib/redirections.js
+++ b/app/lib/redirections.js
@@ -1,0 +1,19 @@
+let cache = [];
+let lastFetch = 0;
+const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+export async function getRedirections(origin) {
+  if (Date.now() - lastFetch > CACHE_DURATION) {
+    try {
+      const res = await fetch(`${origin}/api/v1/admin/redirections`);
+      if (res.ok) {
+        const json = await res.json();
+        cache = Array.isArray(json.data) ? json.data : [];
+        lastFetch = Date.now();
+      }
+    } catch (err) {
+      console.error('Failed to fetch redirections', err);
+    }
+  }
+  return cache;
+}

--- a/app/lib/redirections.js
+++ b/app/lib/redirections.js
@@ -1,6 +1,8 @@
 let cache = [];
 let lastFetch = 0;
-const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+const CACHE_DURATION = process.env.REDIRECTS_CACHE_DURATION
+  ? Number(process.env.REDIRECTS_CACHE_DURATION)
+  : 0; // 0 = no cache by default
 
 export async function getRedirections(origin) {
   if (Date.now() - lastFetch > CACHE_DURATION) {
@@ -16,4 +18,9 @@ export async function getRedirections(origin) {
     }
   }
   return cache;
+}
+
+export function clearRedirectionsCache() {
+  cache = [];
+  lastFetch = 0;
 }


### PR DESCRIPTION
## Summary
- add helper to fetch redirection rules from API
- enable middleware across all routes and apply cached redirects

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a67697c288328898d106e48bf3b65