### PR TITLE
Simplify API requests

### DIFF
--- a/actions/redirections.js
+++ b/actions/redirections.js
@@ -1,20 +1,16 @@
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 
 export async function deleteRedirection(fromUrl) {
-  const token = TokenFromCookie();
   // 1. Get all redirections
-  const resList = await fetch(`/api/v1/admin/redirections`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  const resList = await apiFetch(`/api/v1/admin/redirections`);
   const listData = await resList.json();
   if (!listData.success || !Array.isArray(listData.data)) return { success: false };
   // 2. Find redirection by fromUrl
   const found = listData.data.find((r) => r.from === fromUrl);
   if (!found) return { success: true };
   // 3. Delete by id
-  const res = await fetch(`/api/v1/admin/redirections/${found._id}`, {
+  const res = await apiFetch(`/api/v1/admin/redirections/${found._id}`, {
     method: "DELETE",
-    headers: { Authorization: `Bearer ${token}` },
   });
   const text = await res.text();
   if (!text) return { success: true };

--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -47,7 +47,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 import ImageCropperInput from "@/components/image-cropper-input";
 import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import { useParams, useRouter } from "next/navigation";
@@ -299,10 +299,8 @@ export default function Page() {
       formData.append("bgColorStatus", data.bgColorStatus ? "true" : "false");
       if (data.bgColor !== undefined) formData.append("bgColor", data.bgColor || "");
 
-      const token = TokenFromCookie();
-      const res = await fetch(`/api/v1/admin/blogs/${blogId}`, {
+      const res = await apiFetch(`/api/v1/admin/blogs/${blogId}`, {
         method: "PUT",
-        headers: { Authorization: `Bearer ${token}` },
         body: formData,
       });
       const result = await res.json();

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -47,7 +47,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 import ImageCropperInput from "@/components/image-cropper-input";
 import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import { useSearchParams, useRouter } from "next/navigation";
@@ -333,20 +333,17 @@ function BlogAdd() {
       formData.append("bgColorStatus", data.bgColorStatus ? "true" : "false");
       if (data.bgColor !== undefined) formData.append("bgColor", data.bgColor || "");
 
-      const token = TokenFromCookie();
       let res, result;
       if (blogId) {
         // Update existing blog (draft or publish)
-        res = await fetch(`/api/v1/admin/blogs/${blogId}`, {
+        res = await apiFetch(`/api/v1/admin/blogs/${blogId}`, {
           method: "PUT",
-          headers: { Authorization: `Bearer ${token}` },
           body: formData,
         });
       } else {
         // Create new blog
-        res = await fetch(`/api/v1/admin/blogs`, {
+        res = await apiFetch(`/api/v1/admin/blogs`, {
           method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
           body: formData,
         });
       }
@@ -427,12 +424,10 @@ function BlogAdd() {
         }
       });
       formData.append("status", Number(1)); // Always save as draft (status 1)
-      const token = TokenFromCookie();
       let res, result;
       if (!blogId) {
-        res = await fetch(`/api/v1/admin/blogs`, {
+        res = await apiFetch(`/api/v1/admin/blogs`, {
           method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
           body: formData,
         });
         result = await res.json();
@@ -443,9 +438,8 @@ function BlogAdd() {
           window.history.replaceState({}, "", url.toString());
         }
       } else {
-        res = await fetch(`/api/v1/admin/blogs/${blogId}`, {
+        res = await apiFetch(`/api/v1/admin/blogs/${blogId}`, {
           method: "PUT",
-          headers: { Authorization: `Bearer ${token}` },
           body: formData,
         });
         result = await res.json();

--- a/app/admin/blogs/images/[id]/edit/page.jsx
+++ b/app/admin/blogs/images/[id]/edit/page.jsx
@@ -9,7 +9,7 @@ import * as z from "zod";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import React, { useEffect } from "react";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 
 const imageFormSchema = z.object({
   image: z.any().refine((file) => !file || file.length === 1, "Only one image allowed"),
@@ -28,12 +28,7 @@ export default function EditImagePage({ params }) {
   useEffect(() => {
     async function fetchImage() {
       try {
-        const token = TokenFromCookie();
-        const res = await fetch(`/api/v1/admin/images/${id}`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
+        const res = await apiFetch(`/api/v1/admin/images/${id}`);
         const result = await res.json();
         if (!result.success || !result.data) {
           router.replace("/admin/blogs/images");
@@ -61,12 +56,8 @@ export default function EditImagePage({ params }) {
       if (data.image?.[0]) {
         formData.append('file', data.image[0]);
       }
-      const token = TokenFromCookie();
-      const res = await fetch(`/api/v1/admin/images/${id}`, {
+      const res = await apiFetch(`/api/v1/admin/images/${id}`, {
         method: "PUT",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
         body: formData,
       });
       const json = await res.json();

--- a/app/admin/blogs/images/add/page.jsx
+++ b/app/admin/blogs/images/add/page.jsx
@@ -8,7 +8,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 
 const imageFormSchema = z.object({
   image: z.any().refine((file) => file?.length === 1, "Image is required"),
@@ -27,12 +27,8 @@ export default function AddImagePage() {
       if (data.image?.[0]) {
         formData.append('file', data.image[0]);
       }
-      const token = TokenFromCookie();
-      const res = await fetch("/api/v1/admin/images", {
+      const res = await apiFetch("/api/v1/admin/images", {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
         body: formData,
       });
       const json = await res.json();

--- a/components/authorTable.jsx
+++ b/components/authorTable.jsx
@@ -40,7 +40,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
-import TokenFromCookie from "@/helpers/tokenFromCookie"
+import apiFetch from "@/helpers/apiFetch"
 
 function AuthorActions({ author }) {
   const router = useRouter()
@@ -49,12 +49,8 @@ function AuthorActions({ author }) {
     try {
       const formData = new FormData()
       formData.append('status', status)
-      const token = TokenFromCookie()
-      const res = await fetch(`/api/v1/admin/blogs/authors/${author.id}`, {
+      const res = await apiFetch(`/api/v1/admin/blogs/authors/${author.id}`, {
         method: 'PUT',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
         body: formData,
       })
       const data = await res.json()

--- a/components/blogTable.jsx
+++ b/components/blogTable.jsx
@@ -47,7 +47,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 import RedirectionForm from "@/components/RedirectionForm";
 import { deleteRedirection } from "@/actions/redirections";
 
@@ -72,12 +72,8 @@ function BlogActions({ blog }) {
       const formData = new FormData();
       formData.append("status", status);
       if (publishedDateTime) formData.append("publishedDateTime", publishedDateTime);
-      const token = TokenFromCookie();
-      const res = await fetch(`/api/v1/admin/blogs/${blog.id}`, {
+      const res = await apiFetch(`/api/v1/admin/blogs/${blog.id}`, {
         method: "PUT",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
         body: formData,
       });
       const data = await res.json();
@@ -94,12 +90,8 @@ function BlogActions({ blog }) {
 
   const handleSendNotification = async () => {
     try {
-      const token = TokenFromCookie();
-      const res = await fetch(`/api/v1/admin/blogs/${blog.id}/notify`, {
+      const res = await apiFetch(`/api/v1/admin/blogs/${blog.id}/notify`, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
       });
       const data = await res.json();
       if (data.success) {
@@ -114,12 +106,8 @@ function BlogActions({ blog }) {
 
   const handleDelete = async () => {
     try {
-      const token = TokenFromCookie();
-      const res = await fetch(`/api/v1/admin/blogs/${blog.id}`, {
+      const res = await apiFetch(`/api/v1/admin/blogs/${blog.id}`, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
       });
       const data = await res.json();
       if (data.success) {

--- a/components/categoryTable.jsx
+++ b/components/categoryTable.jsx
@@ -37,7 +37,7 @@ import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 
 function CategoryActions({ category }) {
   const router = useRouter();
@@ -46,12 +46,8 @@ function CategoryActions({ category }) {
     try {
       const formData = new FormData();
       formData.append('status', status);
-      const token = TokenFromCookie();
-      const res = await fetch(`/api/v1/admin/blogs/categories/${category.id}`, {
+      const res = await apiFetch(`/api/v1/admin/blogs/categories/${category.id}`, {
         method: 'PUT',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
         body: formData,
       });
       const data = await res.json();

--- a/components/delete-author-buttons.jsx
+++ b/components/delete-author-buttons.jsx
@@ -4,7 +4,7 @@ import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, Dialo
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 import { Copy } from "lucide-react";
 import Link from "next/link";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -27,13 +27,9 @@ export default function DeleteAuthorButtons({ id }) {
 
   const handleDelete = async () => {
     try {
-      const token = TokenFromCookie();
       const url = `/api/v1/admin/blogs/authors/${id}`;
-      const res = await fetch(url, {
+      const res = await apiFetch(url, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
       });
       const data = await res.json();
       if (data.success) {

--- a/components/delete-blog-buttons.jsx
+++ b/components/delete-blog-buttons.jsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 
 export default function DeleteBlogButtons({ id }) {
   const router = useRouter();
@@ -20,13 +20,9 @@ export default function DeleteBlogButtons({ id }) {
 
   const handleDelete = async () => {
     try {
-      const token = TokenFromCookie();
       const url = `/api/v1/admin/blogs/${id}`;
-      const res = await fetch(url, {
+      const res = await apiFetch(url, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
       });
       const data = await res.json();
       if (data.success) {

--- a/components/delete-category-buttons.jsx
+++ b/components/delete-category-buttons.jsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 import { Copy } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
@@ -27,13 +27,9 @@ export default function DeleteCategoryButtons({ id }) {
 
   const handleDelete = async () => {
     try {
-      const token = TokenFromCookie();
       const url = `/api/v1/admin/blogs/categories/${id}`;
-      const res = await fetch(url, {
+      const res = await apiFetch(url, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
       });
       const data = await res.json();
       if (data.success) {

--- a/components/redirectionTable.jsx
+++ b/components/redirectionTable.jsx
@@ -33,7 +33,7 @@ import {
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import TokenFromCookie from "@/helpers/tokenFromCookie";
+import apiFetch from "@/helpers/apiFetch";
 import {
   Dialog,
   DialogTrigger,
@@ -52,12 +52,8 @@ function RedirectionActions({ redirection }) {
   const handleDelete = async () => {
     setLoading(true);
     try {
-      const token = TokenFromCookie();
-      const res = await fetch(`/api/v1/admin/redirections/${redirection.id}`, {
+      const res = await apiFetch(`/api/v1/admin/redirections/${redirection.id}`, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
       });
       const data = await res.json();
       if (data.success) {

--- a/helpers/apiFetch.js
+++ b/helpers/apiFetch.js
@@ -1,0 +1,15 @@
+import TokenFromCookie from "./tokenFromCookie";
+
+export default function apiFetch(url, options = {}) {
+  const token = TokenFromCookie();
+  const { data, headers = {}, ...rest } = options;
+  const fetchOptions = { headers: { ...headers }, ...rest };
+  if (token) {
+    fetchOptions.headers["Authorization"] = `Bearer ${token}`;
+  }
+  if (data !== undefined) {
+    fetchOptions.headers["Content-Type"] = "application/json";
+    fetchOptions.body = JSON.stringify(data);
+  }
+  return fetch(url, fetchOptions);
+}


### PR DESCRIPTION
## Summary
- add a small `apiFetch` helper for token and JSON handling
- use `apiFetch` in various admin components and pages

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685cf46a20d8832892c76072839862cd