### PR TITLE
Add fetch timeout for redirection middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You can start editing the page by modifying `app/(pages)/page.jsx`. The page aut
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Configuration
+
+The middleware fetches redirect rules from `/api/v1/admin/redirections`. If this request takes too long it can lead to a timeout. You can control how long the middleware waits by setting `REDIRECTS_FETCH_TIMEOUT` (milliseconds) in your environment. It defaults to `3000`. The cache duration of these rules can be configured with `REDIRECTS_CACHE_DURATION`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/lib/redirections.js
+++ b/app/lib/redirections.js
@@ -4,10 +4,19 @@ const CACHE_DURATION = process.env.REDIRECTS_CACHE_DURATION
   ? Number(process.env.REDIRECTS_CACHE_DURATION)
   : 0; // 0 = no cache by default
 
+const FETCH_TIMEOUT = process.env.REDIRECTS_FETCH_TIMEOUT
+  ? Number(process.env.REDIRECTS_FETCH_TIMEOUT)
+  : 3000; // default 3s timeout
+
 export async function getRedirections(origin) {
   if (Date.now() - lastFetch > CACHE_DURATION) {
     try {
-      const res = await fetch(`${origin}/api/v1/admin/redirections`);
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+      const res = await fetch(`${origin}/api/v1/admin/redirections`, {
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
       if (res.ok) {
         const json = await res.json();
         cache = Array.isArray(json.data) ? json.data : [];


### PR DESCRIPTION
## Summary
- avoid long waits when fetching redirect rules
- document new `REDIRECTS_FETCH_TIMEOUT` option

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685cf88ed6dc8328b8dc06654cefcead