### PR TITLE
Implement Lead API endpoints

### DIFF
--- a/app/api/v1/admin/leads/[id]/route.js
+++ b/app/api/v1/admin/leads/[id]/route.js
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import mongoose from 'mongoose';
+import connectDB from '@/app/lib/db';
+import Lead, { LEAD_STATUS } from '@/app/models/Lead';
+
+// GET single lead
+export async function GET(request, { params }) {
+  try {
+    await connectDB();
+    const { id } = params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid lead ID' }, { status: 400 });
+    }
+    const lead = await Lead.findById(id).lean();
+    if (!lead) {
+      return NextResponse.json({ success: false, error: 'Lead not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: lead });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error fetching lead' }, { status: 500 });
+  }
+}
+
+// PUT update lead
+export async function PUT(request, { params }) {
+  try {
+    await connectDB();
+    const { id } = params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid lead ID' }, { status: 400 });
+    }
+    const body = await request.json();
+    const update = {
+      contact_name: body.contact_name,
+      mobile_number: body.mobile_number,
+      email: body.email,
+      organization: body.organization,
+      requirements: body.requirements,
+      description: body.description
+    };
+    if (body.status && [1,2,3].includes(Number(body.status))) {
+      update.status = Number(body.status);
+    }
+    update.modified_date = new Date();
+    const lead = await Lead.findByIdAndUpdate(id, update, { new: true });
+    if (!lead) {
+      return NextResponse.json({ success: false, error: 'Lead not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: lead });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error updating lead' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/leads/[id]/route.js
+++ b/app/api/v1/admin/leads/[id]/route.js
@@ -8,7 +8,7 @@ import { uploadLeadAttachment } from '@/app/middleware/attachmentUpload';
 export async function GET(request, { params }) {
   try {
     await connectDB();
-    const { id } = params;
+    const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return NextResponse.json({ success: false, error: 'Invalid lead ID' }, { status: 400 });
     }
@@ -16,7 +16,7 @@ export async function GET(request, { params }) {
     if (!lead) {
       return NextResponse.json({ success: false, error: 'Lead not found' }, { status: 404 });
     }
-    return NextResponse.json({ success: true, data: lead });
+    return NextResponse.json({ success: true, message: 'Lead fetched successfully', data: lead }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error fetching lead' }, { status: 500 });
   }
@@ -26,7 +26,7 @@ export async function GET(request, { params }) {
 export async function PUT(request, { params }) {
   try {
     await connectDB();
-    const { id } = params;
+    const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return NextResponse.json({ success: false, error: 'Invalid lead ID' }, { status: 400 });
     }
@@ -67,7 +67,7 @@ export async function PUT(request, { params }) {
     lead.modified_date = new Date();
     await lead.save();
 
-    return NextResponse.json({ success: true, data: lead });
+    return NextResponse.json({ success: true, message: 'Lead updated successfully', data: lead }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error updating lead' }, { status: 500 });
   }

--- a/app/api/v1/admin/leads/approved/route.js
+++ b/app/api/v1/admin/leads/approved/route.js
@@ -6,7 +6,7 @@ export async function GET() {
   try {
     await connectDB();
     const leads = await Lead.find({ status: LEAD_STATUS.APPROVED }).sort({ created_date: -1 }).lean();
-    return NextResponse.json({ success: true, data: leads });
+    return NextResponse.json({ success: true, message: 'Leads fetched successfully', data: leads }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
   }

--- a/app/api/v1/admin/leads/approved/route.js
+++ b/app/api/v1/admin/leads/approved/route.js
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Lead, { LEAD_STATUS } from '@/app/models/Lead';
+
+export async function GET() {
+  try {
+    await connectDB();
+    const leads = await Lead.find({ status: LEAD_STATUS.APPROVED }).sort({ created_date: -1 }).lean();
+    return NextResponse.json({ success: true, data: leads });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/leads/rejected/route.js
+++ b/app/api/v1/admin/leads/rejected/route.js
@@ -6,7 +6,7 @@ export async function GET() {
   try {
     await connectDB();
     const leads = await Lead.find({ status: LEAD_STATUS.REJECTED }).sort({ created_date: -1 }).lean();
-    return NextResponse.json({ success: true, data: leads });
+    return NextResponse.json({ success: true, message: 'Leads fetched successfully', data: leads }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
   }

--- a/app/api/v1/admin/leads/rejected/route.js
+++ b/app/api/v1/admin/leads/rejected/route.js
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Lead, { LEAD_STATUS } from '@/app/models/Lead';
+
+export async function GET() {
+  try {
+    await connectDB();
+    const leads = await Lead.find({ status: LEAD_STATUS.REJECTED }).sort({ created_date: -1 }).lean();
+    return NextResponse.json({ success: true, data: leads });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/leads/route.js
+++ b/app/api/v1/admin/leads/route.js
@@ -8,7 +8,7 @@ export async function GET() {
   try {
     await connectDB();
     const leads = await Lead.find().sort({ created_date: -1 }).lean();
-    return NextResponse.json({ success: true, data: leads });
+    return NextResponse.json({ success: true, message: 'Leads fetched successfully', data: leads }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
   }
@@ -47,7 +47,7 @@ export async function POST(request) {
       attachments,
       status: formData.get('status') && [1,2,3].includes(Number(formData.get('status'))) ? Number(formData.get('status')) : LEAD_STATUS.UPCOMING
     });
-    return NextResponse.json({ success: true, data: lead }, { status: 201 });
+    return NextResponse.json({ success: true, message: 'Lead created successfully', data: lead }, { status: 201 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error creating lead' }, { status: 500 });
   }

--- a/app/api/v1/admin/leads/route.js
+++ b/app/api/v1/admin/leads/route.js
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Lead, { LEAD_STATUS } from '@/app/models/Lead';
+
+// GET all leads
+export async function GET() {
+  try {
+    await connectDB();
+    const leads = await Lead.find().sort({ created_date: -1 }).lean();
+    return NextResponse.json({ success: true, data: leads });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
+  }
+}
+
+// POST add new lead
+export async function POST(request) {
+  try {
+    await connectDB();
+    const body = await request.json();
+    const lead = await Lead.create({
+      contact_name: body.contact_name || null,
+      mobile_number: body.mobile_number || null,
+      email: body.email || null,
+      organization: body.organization || null,
+      requirements: body.requirements || null,
+      description: body.description || null,
+      status: body.status && [1,2,3].includes(Number(body.status)) ? Number(body.status) : LEAD_STATUS.UPCOMING
+    });
+    return NextResponse.json({ success: true, data: lead }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error creating lead' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/leads/upcoming/route.js
+++ b/app/api/v1/admin/leads/upcoming/route.js
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Lead, { LEAD_STATUS } from '@/app/models/Lead';
+
+export async function GET() {
+  try {
+    await connectDB();
+    const leads = await Lead.find({ status: LEAD_STATUS.UPCOMING }).sort({ created_date: -1 }).lean();
+    return NextResponse.json({ success: true, data: leads });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/leads/upcoming/route.js
+++ b/app/api/v1/admin/leads/upcoming/route.js
@@ -6,7 +6,7 @@ export async function GET() {
   try {
     await connectDB();
     const leads = await Lead.find({ status: LEAD_STATUS.UPCOMING }).sort({ created_date: -1 }).lean();
-    return NextResponse.json({ success: true, data: leads });
+    return NextResponse.json({ success: true, message: 'Leads fetched successfully', data: leads }, { status: 200 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error fetching leads' }, { status: 500 });
   }

--- a/app/middleware/attachmentUpload.js
+++ b/app/middleware/attachmentUpload.js
@@ -1,0 +1,42 @@
+import { fileTypeFromBuffer } from 'file-type';
+import { uploadBuffer } from '@/lib/s3';
+
+const PREFIX = 'uploads/leads';
+
+const ALLOWED_TYPES = {
+  'application/pdf': 'pdf',
+  'application/msword': 'doc',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  'application/vnd.ms-excel': 'xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/zip': 'zip',
+  'application/x-zip-compressed': 'zip',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif'
+};
+
+export async function uploadLeadAttachment(file) {
+  try {
+    if (!file || typeof file !== 'object' || typeof file.arrayBuffer !== 'function') {
+      return { success: false, error: 'Please provide a valid file' };
+    }
+
+    const buffer = await file.arrayBuffer();
+    const type = await fileTypeFromBuffer(Buffer.from(buffer));
+    if (!type || !ALLOWED_TYPES[type.mime]) {
+      return { success: false, error: 'Invalid file type. Only PDF, Word, Excel, Zip, or image files allowed' };
+    }
+
+    const ext = ALLOWED_TYPES[type.mime];
+    const filename = `lead-${Date.now()}.${ext}`;
+    const key = `${PREFIX}/${filename}`;
+    await uploadBuffer(Buffer.from(buffer), key, type.mime);
+
+    return { success: true, filename };
+  } catch (error) {
+    console.error('Error uploading attachment:', error);
+    return { success: false, error: 'Error uploading attachment' };
+  }
+}

--- a/app/models/Lead.js
+++ b/app/models/Lead.js
@@ -14,6 +14,10 @@ const leadSchema = new mongoose.Schema(
     organization: { type: String, default: null },
     requirements: { type: String, default: null },
     description: { type: String, default: null },
+    attachments: { type: [String], default: [] },
+    path: { type: String, default: null },
+    assign_to: { type: mongoose.Schema.Types.ObjectId, ref: 'Admin', default: null },
+    assigned_date: { type: Date, default: null },
     status: { type: Number, enum: [1, 2, 3], default: LEAD_STATUS.UPCOMING },
     created_date: { type: Date, default: Date.now },
     modified_date: { type: Date, default: Date.now }

--- a/app/models/Lead.js
+++ b/app/models/Lead.js
@@ -1,0 +1,28 @@
+import mongoose from 'mongoose';
+
+export const LEAD_STATUS = {
+  UPCOMING: 1,
+  APPROVED: 2,
+  REJECTED: 3
+};
+
+const leadSchema = new mongoose.Schema(
+  {
+    contact_name: { type: String, default: null },
+    mobile_number: { type: String, default: null },
+    email: { type: String, default: null },
+    organization: { type: String, default: null },
+    requirements: { type: String, default: null },
+    description: { type: String, default: null },
+    status: { type: Number, enum: [1, 2, 3], default: LEAD_STATUS.UPCOMING },
+    created_date: { type: Date, default: Date.now },
+    modified_date: { type: Date, default: Date.now }
+  },
+  {
+    timestamps: { createdAt: 'created_date', updatedAt: 'modified_date' }
+  }
+);
+
+const Lead = mongoose.models.Lead || mongoose.model('Lead', leadSchema);
+
+export default Lead;


### PR DESCRIPTION
## Summary
- add mongoose model for leads
- provide CRUD API routes for leads
- add filter routes for approved/rejected/upcoming leads

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cf9e643e883289e06c504547672ec