### PR TITLE
Update redirection API to sync JSON and DB

### DIFF
--- a/actions/redirections.js
+++ b/actions/redirections.js
@@ -9,7 +9,7 @@ export async function deleteRedirection(fromUrl) {
   const found = listData.data.find((r) => r.from === fromUrl);
   if (!found) return { success: true };
   // 3. Delete by id
-  const res = await apiFetch(`/api/v1/admin/redirections/${found._id}`, {
+  const res = await apiFetch(`/api/v1/admin/redirections/${found.id}`, {
     method: "DELETE",
   });
   const text = await res.text();

--- a/app/admin/redirections/[id]/edit/EditRedirectionForm.jsx
+++ b/app/admin/redirections/[id]/edit/EditRedirectionForm.jsx
@@ -47,10 +47,12 @@ export default function EditRedirectionForm({ redirection }) {
       const data = await res.json();
       if (data.success) {
         toast.success("Redirection updated successfully");
+        if (data.notice) toast.info(data.notice);
         router.push("/admin/redirections");
         router.refresh();
       } else {
         toast.error(data.error || "Failed to update redirection");
+        if (data.notice) toast.info(data.notice);
       }
     } catch (err) {
       toast.error("Something went wrong");

--- a/app/admin/redirections/add/page.jsx
+++ b/app/admin/redirections/add/page.jsx
@@ -46,10 +46,12 @@ export default function AddRedirectionPage() {
       const data = await res.json();
       if (data.success) {
         toast.success("Redirection added successfully");
+        if (data.notice) toast.info(data.notice);
         form.reset();
         router.push("/admin/redirections");
       } else {
         toast.error(data.error || "Failed to add redirection");
+        if (data.notice) toast.info(data.notice);
       }
     } catch (err) {
       toast.error("Something went wrong");

--- a/components/RedirectionForm.jsx
+++ b/components/RedirectionForm.jsx
@@ -46,11 +46,13 @@ export default function RedirectionForm({ fromDefault = "", onSuccess }) {
       const data = await res.json();
       if (data.success) {
         toast.success("Redirection added successfully");
+        if (data.notice) toast.info(data.notice);
         form.reset();
         if (onSuccess) onSuccess();
         else router.push("/admin/redirections");
       } else {
         toast.error(data.error || "Failed to add redirection");
+        if (data.notice) toast.info(data.notice);
       }
     } catch (err) {
       toast.error("Something went wrong");

--- a/components/redirectionTable.jsx
+++ b/components/redirectionTable.jsx
@@ -58,10 +58,12 @@ function RedirectionActions({ redirection }) {
       const data = await res.json();
       if (data.success) {
         toast.success("Redirection deleted");
+        if (data.notice) toast.info(data.notice);
         setOpen(false);
         router.refresh();
       } else {
         toast.error(data.error || "Failed to delete redirection");
+        if (data.notice) toast.info(data.notice);
       }
     } catch (error) {
       toast.error("Failed to delete redirection");


### PR DESCRIPTION
## Summary
- sync `redirections.json` with MongoDB
- re-create json file if missing and inform the user
- update API routes to read/write database and keep JSON updated
- show info toast on admin pages when the json file is recreated
- fix id usage in `actions/deleteRedirection`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d2cbc2d3c8328b1618b182b6cf467