### PR TITLE
Add newsletter API

### DIFF
--- a/app/api/v1/admin/newsletters/[id]/route.js
+++ b/app/api/v1/admin/newsletters/[id]/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import mongoose from 'mongoose';
+import connectDB from '@/app/lib/db';
+import Newsletter from '@/app/models/Newsletter';
+import { extractToken, verifyToken } from '@/app/lib/auth';
+
+export async function DELETE(request, { params }) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+    await connectDB();
+    const { id } = await params;
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ success: false, error: 'Invalid ID' }, { status: 400 });
+    }
+    const deleted = await Newsletter.findByIdAndDelete(id);
+    if (!deleted) {
+      return NextResponse.json({ success: false, error: 'Newsletter not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, message: 'Newsletter deleted successfully', data: deleted });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error deleting newsletter' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/newsletters/route.js
+++ b/app/api/v1/admin/newsletters/route.js
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import Newsletter from '@/app/models/Newsletter';
+import { extractToken, verifyToken } from '@/app/lib/auth';
+
+// GET all newsletter emails
+export async function GET() {
+  try {
+    await connectDB();
+    const emails = await Newsletter.find().sort({ createdAt: -1 }).lean();
+    return NextResponse.json({ success: true, data: emails });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error fetching newsletters' }, { status: 500 });
+  }
+}
+
+// POST add new email
+export async function POST(request) {
+  try {
+    await connectDB();
+    const body = await request.json();
+    if (!body?.email) {
+      return NextResponse.json({ success: false, error: 'Email is required' }, { status: 400 });
+    }
+    const existing = await Newsletter.findOne({ email: body.email });
+    if (existing) {
+      return NextResponse.json({ success: false, error: 'Email already subscribed' }, { status: 409 });
+    }
+    const newsletter = await Newsletter.create({ email: body.email });
+    return NextResponse.json({ success: true, data: newsletter }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ success: false, error: 'Error subscribing to newsletter' }, { status: 500 });
+  }
+}

--- a/app/models/Newsletter.js
+++ b/app/models/Newsletter.js
@@ -1,0 +1,7 @@
+import mongoose from 'mongoose';
+
+const newsletterSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+}, { timestamps: true });
+
+export default mongoose.models.Newsletter || mongoose.model('Newsletter', newsletterSchema);


### PR DESCRIPTION
## Summary
- create Newsletter model
- add API route to manage newsletter emails
- implement deletion endpoint for newsletter entries

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d2e9222788328a73305bdcec23020