### PR TITLE
Add admin lead and newsletter pages

### DIFF
--- a/app/admin/leads/[id]/edit/page.jsx
+++ b/app/admin/leads/[id]/edit/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { use, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -23,7 +23,7 @@ const leadSchema = z.object({
 
 export default function Page({ params }) {
   const router = useRouter();
-  const { id } = params;
+  const { id } = use(params);
   const form = useForm({ resolver: zodResolver(leadSchema), defaultValues: { contact_name: "", mobile_number: "", email: "", organization: "", requirements: "", description: "" } });
 
   useEffect(() => {

--- a/app/admin/leads/[id]/edit/page.jsx
+++ b/app/admin/leads/[id]/edit/page.jsx
@@ -1,0 +1,123 @@
+"use client";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { useRouter } from "next/navigation";
+import apiFetch from "@/helpers/apiFetch";
+import { toast } from "sonner";
+
+const leadSchema = z.object({
+  contact_name: z.string().optional(),
+  mobile_number: z.string().optional(),
+  email: z.string().email().optional().or(z.literal("")),
+  organization: z.string().optional().or(z.literal("")),
+  requirements: z.string().optional().or(z.literal("")),
+  description: z.string().optional().or(z.literal("")),
+});
+
+export default function Page({ params }) {
+  const router = useRouter();
+  const { id } = params;
+  const form = useForm({ resolver: zodResolver(leadSchema), defaultValues: { contact_name: "", mobile_number: "", email: "", organization: "", requirements: "", description: "" } });
+
+  useEffect(() => {
+    async function fetchLead() {
+      const res = await fetch(`/api/v1/admin/leads/${id}`);
+      const data = await res.json();
+      if (data.success && data.data) {
+        form.reset({
+          contact_name: data.data.contact_name || "",
+          mobile_number: data.data.mobile_number || "",
+          email: data.data.email || "",
+          organization: data.data.organization || "",
+          requirements: data.data.requirements || "",
+          description: data.data.description || "",
+        });
+      }
+    }
+    fetchLead();
+  }, [id]);
+
+  async function onSubmit(values) {
+    const formData = new FormData();
+    Object.entries(values).forEach(([key, val]) => {
+      if (val) formData.append(key, val);
+    });
+    const res = await apiFetch(`/api/v1/admin/leads/${id}`, { method: 'PUT', body: formData });
+    const result = await res.json();
+    if (result.success) {
+      toast.success('Lead updated');
+      router.push(`/admin/leads/${id}`);
+      router.refresh();
+    } else {
+      toast.error(result.error || 'Failed to update');
+    }
+  }
+
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Edit Lead</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField name="contact_name" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="mobile_number" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Mobile</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="email" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="organization" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Organization</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="requirements" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Requirements</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="description" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <div className="flex justify-end">
+                <Button type="submit" disabled={form.formState.isSubmitting}>{form.formState.isSubmitting ? 'Saving...' : 'Save'}</Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/leads/[id]/page.jsx
+++ b/app/admin/leads/[id]/page.jsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default async function Page({ params }) {
+  const { id } = params;
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/${id}`, { cache: 'no-store' });
+  const json = await res.json();
+  const lead = json?.data;
+
+  if (!lead) {
+    return <div className="p-4">Lead not found</div>;
+  }
+
+  const statusMap = { 1: 'Upcoming', 2: 'Approved', 3: 'Rejected' };
+
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Lead Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            <p><strong>Name:</strong> {lead.contact_name}</p>
+            <p><strong>Email:</strong> {lead.email}</p>
+            <p><strong>Mobile:</strong> {lead.mobile_number}</p>
+            <p><strong>Organization:</strong> {lead.organization}</p>
+            <p><strong>Requirements:</strong> {lead.requirements}</p>
+            <p><strong>Description:</strong> {lead.description}</p>
+            <p><strong>Status:</strong> {statusMap[lead.status]}</p>
+            {lead.assign_to && <p><strong>Assigned To:</strong> {lead.assign_to}</p>}
+            {lead.assigned_date && <p><strong>Assigned Date:</strong> {new Date(lead.assigned_date).toLocaleString()}</p>}
+            <p><strong>Created:</strong> {new Date(lead.created_date).toLocaleString()}</p>
+          </div>
+          <div className="mt-4">
+            <Link href={`/admin/leads/${lead._id}/edit`}>
+              <Button type="button">Edit</Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/leads/[id]/page.jsx
+++ b/app/admin/leads/[id]/page.jsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
 export default async function Page({ params }) {
-  const { id } = params;
+  const { id } = await params;
   const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/${id}`, { cache: 'no-store' });
   const json = await res.json();
   const lead = json?.data;

--- a/app/admin/leads/add/page.jsx
+++ b/app/admin/leads/add/page.jsx
@@ -1,0 +1,117 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import apiFetch from "@/helpers/apiFetch";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+
+const leadSchema = z.object({
+  contact_name: z.string().min(1, { message: "Name is required" }),
+  mobile_number: z.string().min(1, { message: "Mobile is required" }),
+  email: z.string().email().optional().or(z.literal("")),
+  organization: z.string().optional().or(z.literal("")),
+  requirements: z.string().optional().or(z.literal("")),
+  description: z.string().optional().or(z.literal("")),
+  attachments: z.any().optional(),
+});
+
+export default function Page() {
+  const router = useRouter();
+  const form = useForm({ resolver: zodResolver(leadSchema), defaultValues: { contact_name: "", mobile_number: "", email: "", organization: "", requirements: "", description: "" } });
+
+  async function onSubmit(values) {
+    const formData = new FormData();
+    formData.append('contact_name', values.contact_name);
+    formData.append('mobile_number', values.mobile_number);
+    if (values.email) formData.append('email', values.email);
+    if (values.organization) formData.append('organization', values.organization);
+    if (values.requirements) formData.append('requirements', values.requirements);
+    if (values.description) formData.append('description', values.description);
+    if (values.attachments && values.attachments.length) {
+      for (const file of values.attachments) formData.append('attachments', file);
+    }
+    const res = await apiFetch('/api/v1/admin/leads', { method: 'POST', body: formData });
+    const result = await res.json();
+    if (result.success) {
+      toast.success('Lead created');
+      form.reset();
+      router.push('/admin/leads');
+      router.refresh();
+    } else {
+      toast.error(result.error || 'Failed to create');
+    }
+  }
+
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Lead</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField name="contact_name" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="mobile_number" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Mobile</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="email" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="organization" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Organization</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="requirements" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Requirements</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="description" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="attachments" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Attachments</FormLabel>
+                  <FormControl><Input type="file" multiple onChange={e => field.onChange(e.target.files)} /></FormControl>
+                </FormItem>
+              )} />
+              <div className="flex justify-end">
+                <Button type="submit" disabled={form.formState.isSubmitting}>{form.formState.isSubmitting ? 'Creating...' : 'Create'}</Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/leads/approved/page.jsx
+++ b/app/admin/leads/approved/page.jsx
@@ -1,0 +1,24 @@
+import { LeadTable } from "@/components/leadTable";
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/approved`, { cache: 'no-store' });
+  const json = await res.json();
+  const leads = Array.isArray(json?.data) ? json.data : [];
+  const data = leads.map(lead => ({
+    id: lead._id,
+    contact_name: lead.contact_name,
+    mobile_number: lead.mobile_number,
+    email: lead.email,
+    organization: lead.organization,
+    requirements: lead.requirements,
+    status: 'approved',
+    created_date: lead.created_date,
+    assign_to: lead.assign_to,
+  }));
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <LeadTable data={data} />
+    </div>
+  );
+}

--- a/app/admin/leads/page.jsx
+++ b/app/admin/leads/page.jsx
@@ -1,0 +1,25 @@
+import { LeadTable } from "@/components/leadTable";
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads`, { cache: 'no-store' });
+  const json = await res.json();
+  const leads = Array.isArray(json?.data) ? json.data : [];
+  const statusMap = { 1: 'upcoming', 2: 'approved', 3: 'rejected' };
+  const data = leads.map(lead => ({
+    id: lead._id,
+    contact_name: lead.contact_name,
+    mobile_number: lead.mobile_number,
+    email: lead.email,
+    organization: lead.organization,
+    requirements: lead.requirements,
+    status: statusMap[lead.status] || 'upcoming',
+    created_date: lead.created_date,
+    assign_to: lead.assign_to,
+  }));
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <LeadTable data={data} />
+    </div>
+  );
+}

--- a/app/admin/leads/rejected/page.jsx
+++ b/app/admin/leads/rejected/page.jsx
@@ -1,0 +1,24 @@
+import { LeadTable } from "@/components/leadTable";
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/rejected`, { cache: 'no-store' });
+  const json = await res.json();
+  const leads = Array.isArray(json?.data) ? json.data : [];
+  const data = leads.map(lead => ({
+    id: lead._id,
+    contact_name: lead.contact_name,
+    mobile_number: lead.mobile_number,
+    email: lead.email,
+    organization: lead.organization,
+    requirements: lead.requirements,
+    status: 'rejected',
+    created_date: lead.created_date,
+    assign_to: lead.assign_to,
+  }));
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <LeadTable data={data} />
+    </div>
+  );
+}

--- a/app/admin/leads/upcoming/page.jsx
+++ b/app/admin/leads/upcoming/page.jsx
@@ -1,0 +1,24 @@
+import { LeadTable } from "@/components/leadTable";
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/upcoming`, { cache: 'no-store' });
+  const json = await res.json();
+  const leads = Array.isArray(json?.data) ? json.data : [];
+  const data = leads.map(lead => ({
+    id: lead._id,
+    contact_name: lead.contact_name,
+    mobile_number: lead.mobile_number,
+    email: lead.email,
+    organization: lead.organization,
+    requirements: lead.requirements,
+    status: 'upcoming',
+    created_date: lead.created_date,
+    assign_to: lead.assign_to,
+  }));
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <LeadTable data={data} />
+    </div>
+  );
+}

--- a/app/admin/newsletter/add/page.jsx
+++ b/app/admin/newsletter/add/page.jsx
@@ -1,0 +1,57 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import apiFetch from "@/helpers/apiFetch";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+
+const schema = z.object({ email: z.string().email() });
+
+export default function Page() {
+  const router = useRouter();
+  const form = useForm({ resolver: zodResolver(schema), defaultValues: { email: "" } });
+
+  async function onSubmit(values) {
+    const res = await apiFetch('/api/v1/admin/newsletters', { method: 'POST', data: values });
+    const result = await res.json();
+    if (result.success) {
+      toast.success('Subscribed');
+      form.reset();
+      router.push('/admin/newsletter');
+      router.refresh();
+    } else {
+      toast.error(result.error || 'Failed');
+    }
+  }
+
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Email</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField name="email" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <div className="flex justify-end">
+                <Button type="submit" disabled={form.formState.isSubmitting}>{form.formState.isSubmitting ? 'Submitting...' : 'Submit'}</Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/newsletter/page.jsx
+++ b/app/admin/newsletter/page.jsx
@@ -1,0 +1,18 @@
+import { NewsletterTable } from "@/components/newsletterTable";
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/newsletters`, { cache: 'no-store' });
+  const json = await res.json();
+  const newsletters = Array.isArray(json?.data) ? json.data : [];
+  const data = newsletters.map(n => ({
+    id: n._id,
+    email: n.email,
+    createdAt: n.createdAt,
+  }));
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <NewsletterTable data={data} />
+    </div>
+  );
+}

--- a/components/leadTable.jsx
+++ b/components/leadTable.jsx
@@ -1,0 +1,388 @@
+"use client";
+import * as React from "react";
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowUpDown, ChevronDown, MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import apiFetch from "@/helpers/apiFetch";
+
+function LeadActions({ lead }) {
+  const router = useRouter();
+  const [openAssign, setOpenAssign] = React.useState(false);
+  const [assignTo, setAssignTo] = React.useState(lead.assign_to || "");
+
+  const handleStatusChange = async (status) => {
+    try {
+      const formData = new FormData();
+      formData.append("status", status);
+      const res = await apiFetch(`/api/v1/admin/leads/${lead.id}`, {
+        method: "PUT",
+        body: formData,
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success("Status updated");
+        router.refresh();
+      } else {
+        toast.error(data.error || "Failed to update status");
+      }
+    } catch (error) {
+      toast.error("Failed to update status");
+    }
+  };
+
+  const handleAssign = async () => {
+    try {
+      const formData = new FormData();
+      formData.append("assign_to", assignTo);
+      formData.append("assigned_date", new Date().toISOString());
+      const res = await apiFetch(`/api/v1/admin/leads/${lead.id}`, {
+        method: "PUT",
+        body: formData,
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success("Lead assigned");
+        router.refresh();
+      } else {
+        toast.error(data.error || "Failed to assign lead");
+      }
+    } catch (error) {
+      toast.error("Failed to assign lead");
+    } finally {
+      setOpenAssign(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={openAssign} onOpenChange={setOpenAssign}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Assign Lead</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={assignTo}
+            onChange={(e) => setAssignTo(e.target.value)}
+            placeholder="Admin ID"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpenAssign(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleAssign}>Assign</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="h-8 w-8 p-0">
+            <span className="sr-only">Open menu</span>
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+          <DropdownMenuItem asChild>
+            <Link href={`/admin/leads/${lead.id}/edit`}>Edit</Link>
+          </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Change Status</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem onClick={() => handleStatusChange(1)}>
+                Upcoming
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleStatusChange(2)}>
+                Approved
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleStatusChange(3)}>
+                Rejected
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => setOpenAssign(true)}>
+            Assign To
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  );
+}
+
+export const columns = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "contact_name",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Name
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+    cell: ({ row }) => (
+      <div className="font-medium">
+        <Link href={`/admin/leads/${row.original.id}`} className="hover:underline">
+          {row.getValue("contact_name")}
+        </Link>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "mobile_number",
+    header: "Mobile",
+  },
+  {
+    accessorKey: "email",
+    header: "Email",
+  },
+  {
+    accessorKey: "organization",
+    header: "Organization",
+  },
+  {
+    accessorKey: "requirements",
+    header: "Requirements",
+    cell: ({ row }) => (
+      <div className="line-clamp-2">{row.getValue("requirements")}</div>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      const status = row.getValue("status");
+      return (
+        <Badge
+          variant={status === "approved" ? "default" : "secondary"}
+          className="capitalize"
+        >
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: "created_date",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Created Date
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+    cell: ({ row }) => {
+      const date = new Date(row.getValue("created_date"));
+      return new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+    },
+  },
+  {
+    id: "actions",
+    enableHiding: false,
+    cell: ({ row }) => <LeadActions lead={row.original} />,
+  },
+];
+
+export function LeadTable({ data }) {
+  const [sorting, setSorting] = React.useState([]);
+  const [columnFilters, setColumnFilters] = React.useState([]);
+  const [columnVisibility, setColumnVisibility] = React.useState({});
+  const [rowSelection, setRowSelection] = React.useState({});
+
+  const table = useReactTable({
+    data,
+    columns,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+    },
+  });
+
+  return (
+    <div className="w-full">
+      <div className="flex gap-3 items-center py-4">
+        <Input
+          placeholder="Filter by name..."
+          value={table.getColumn("contact_name")?.getFilterValue() ?? ""}
+          onChange={(event) =>
+            table.getColumn("contact_name")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="ml-auto">
+              Columns <ChevronDown className="ml-2 h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {table
+              .getAllColumns()
+              .filter((column) => column.getCanHide())
+              .map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  className="capitalize"
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                >
+                  {column.id}
+                </DropdownMenuCheckboxItem>
+              ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button asChild>
+          <Link href="/admin/leads/add">Add Lead</Link>
+        </Button>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <div className="text-muted-foreground flex-1 text-sm">
+          {table.getFilteredSelectedRowModel().rows.length} of{' '}
+          {table.getFilteredRowModel().rows.length} row(s) selected.
+        </div>
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/newsletterTable.jsx
+++ b/components/newsletterTable.jsx
@@ -1,0 +1,297 @@
+"use client";
+import * as React from "react";
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowUpDown, ChevronDown, MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import apiFetch from "@/helpers/apiFetch";
+
+function NewsletterActions({ newsletter }) {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+
+  const handleDelete = async () => {
+    try {
+      const res = await apiFetch(`/api/v1/admin/newsletters/${newsletter.id}`, {
+        method: "DELETE",
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success("Deleted");
+        router.refresh();
+      } else {
+        toast.error(data.error || "Failed to delete");
+      }
+    } catch (error) {
+      toast.error("Failed to delete");
+    } finally {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="h-8 w-8 p-0">
+            <span className="sr-only">Open menu</span>
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+          <DropdownMenuItem onClick={() => setOpen(true)}>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Newsletter</DialogTitle>
+          <DialogDescription>
+            This will permanently delete the email. Continue?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete}>
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export const columns = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "email",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Email
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+  },
+  {
+    accessorKey: "createdAt",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Subscribed At
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
+    cell: ({ row }) => {
+      const date = new Date(row.getValue("createdAt"));
+      return new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+    },
+  },
+  {
+    id: "actions",
+    enableHiding: false,
+    cell: ({ row }) => <NewsletterActions newsletter={row.original} />,
+  },
+];
+
+export function NewsletterTable({ data }) {
+  const [sorting, setSorting] = React.useState([]);
+  const [columnFilters, setColumnFilters] = React.useState([]);
+  const [columnVisibility, setColumnVisibility] = React.useState({});
+  const [rowSelection, setRowSelection] = React.useState({});
+
+  const table = useReactTable({
+    data,
+    columns,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+    },
+  });
+
+  return (
+    <div className="w-full">
+      <div className="flex gap-3 items-center py-4">
+        <Input
+          placeholder="Filter by email..."
+          value={table.getColumn("email")?.getFilterValue() ?? ""}
+          onChange={(event) =>
+            table.getColumn("email")?.setFilterValue(event.target.value)
+          }
+          className="max-w-sm"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="ml-auto">
+              Columns <ChevronDown className="ml-2 h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {table
+              .getAllColumns()
+              .filter((column) => column.getCanHide())
+              .map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column.id}
+                  className="capitalize"
+                  checked={column.getIsVisible()}
+                  onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                >
+                  {column.id}
+                </DropdownMenuCheckboxItem>
+              ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button asChild>
+          <Link href="/admin/newsletter/add">Add</Link>
+        </Button>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <div className="text-muted-foreground flex-1 text-sm">
+          {table.getFilteredSelectedRowModel().rows.length} of{' '}
+          {table.getFilteredRowModel().rows.length} row(s) selected.
+        </div>
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `LeadTable` and `NewsletterTable` components
- create lead management pages (list, add, edit, detail, status filtered)
- add newsletter list and add pages

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d384c29308328bd61a08e79c6bb9c