### PR TITLE
Add static meta management API and admin UI

### DIFF
--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -1,0 +1,49 @@
+"use client";
+import { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+export default function EditStaticMetaForm({ meta }) {
+  const [value, setValue] = useState(JSON.stringify(meta, null, 2));
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/v1/admin/meta/static', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: value,
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success('Meta updated successfully');
+      } else {
+        toast.error(data.error || 'Failed to update meta');
+      }
+    } catch {
+      toast.error('Something went wrong');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Edit Static Meta</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <Textarea className="min-h-[400px]" value={value} onChange={(e) => setValue(e.target.value)} />
+          <Button type="submit" disabled={loading} className="w-full">
+            {loading ? 'Updating...' : 'Update Meta'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/meta/static/page.jsx
+++ b/app/admin/meta/static/page.jsx
@@ -1,0 +1,13 @@
+import EditStaticMetaForm from './EditStaticMetaForm';
+
+export default async function Page() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/static`, { cache: 'no-store' });
+  const json = await res.json();
+  const meta = json?.data || {};
+
+  return (
+    <div className="w-full p-4">
+      <EditStaticMetaForm meta={meta} />
+    </div>
+  );
+}

--- a/app/api/v1/admin/meta/static/route.js
+++ b/app/api/v1/admin/meta/static/route.js
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import StaticMeta from '@/app/models/StaticMeta';
+import { staticMetaSchema } from '@/app/lib/validations/staticMeta';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function GET() {
+  try {
+    await connectDB();
+    const meta = await StaticMeta.findOne().lean();
+    if (!meta) {
+      return NextResponse.json({ success: false, error: 'Static meta not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: meta });
+  } catch (error) {
+    console.error('Error fetching static meta:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching static meta' }, { status: 500 });
+  }
+}
+
+export async function PUT(request) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const parsed = staticMetaSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: parsed.error.errors[0].message }, { status: 400 });
+    }
+
+    await connectDB();
+    let meta = await StaticMeta.findOne();
+    if (!meta) {
+      meta = await StaticMeta.create(parsed.data);
+    } else {
+      Object.assign(meta, parsed.data);
+      await meta.save();
+    }
+    return NextResponse.json({ success: true, data: meta });
+  } catch (error) {
+    console.error('Error updating static meta:', error);
+    return NextResponse.json({ success: false, error: 'Error updating static meta' }, { status: 500 });
+  }
+}

--- a/app/lib/validations/staticMeta.js
+++ b/app/lib/validations/staticMeta.js
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+const image = z.object({
+  url: z.string().url(),
+  width: z.number(),
+  height: z.number(),
+  alt: z.string(),
+  type: z.string(),
+});
+
+export const staticMetaSchema = z.object({
+  creator: z.string(),
+  publisher: z.string(),
+  applicationName: z.string(),
+  verification: z.object({
+    google: z.string(),
+    microsoft: z.string(),
+    other: z.object({ fb: z.string() }),
+  }),
+  appleWebApp: z.object({
+    title: z.string(),
+    statusBarStyle: z.string(),
+    capable: z.boolean(),
+    startupImage: z.object({
+      mainImageUrl: z.string(),
+      url: z.string(),
+    }),
+  }),
+  icons: z.object({
+    icon: z.array(z.object({ url: z.string(), sizes: z.string() })),
+    shortcut: z.string(),
+    apple: z.string(),
+    other: z.array(z.object({ rel: z.string(), url: z.string(), color: z.string().optional() })),
+  }),
+  generator: z.string(),
+  formatDetection: z.object({
+    email: z.boolean(),
+    address: z.boolean(),
+    telephone: z.boolean(),
+  }),
+  pinterest: z.object({ richPin: z.boolean() }),
+  category: z.string(),
+  twitter: z.object({
+    site: z.string(),
+    creator: z.string(),
+    images: z.array(z.string()),
+  }),
+  openGraph: z.object({
+    url: z.string(),
+    siteName: z.string(),
+    locale: z.string(),
+    type: z.string(),
+    images: z.array(image),
+  }),
+  authors: z.array(z.object({ name: z.string(), url: z.string().optional() })),
+  keywords: z.array(z.string()),
+  description: z.string(),
+  title: z.object({ default: z.string() }),
+});

--- a/app/models/StaticMeta.js
+++ b/app/models/StaticMeta.js
@@ -1,0 +1,67 @@
+import mongoose from 'mongoose';
+
+const imageSchema = new mongoose.Schema({
+  url: { type: String, required: true },
+  width: { type: Number, required: true },
+  height: { type: Number, required: true },
+  alt: { type: String, required: true },
+  type: { type: String, required: true },
+}, { _id: false });
+
+const staticMetaSchema = new mongoose.Schema({
+  creator: { type: String, required: true },
+  publisher: { type: String, required: true },
+  applicationName: { type: String, required: true },
+  verification: {
+    google: { type: String, required: true },
+    microsoft: { type: String, required: true },
+    other: {
+      fb: { type: String, required: true },
+    },
+  },
+  appleWebApp: {
+    title: { type: String, required: true },
+    statusBarStyle: { type: String, required: true },
+    capable: { type: Boolean, required: true },
+    startupImage: {
+      mainImageUrl: { type: String, required: true },
+      url: { type: String, required: true },
+    },
+  },
+  icons: {
+    icon: [{ url: { type: String, required: true }, sizes: { type: String, required: true } }],
+    shortcut: { type: String, required: true },
+    apple: { type: String, required: true },
+    other: [{ rel: { type: String, required: true }, url: { type: String, required: true }, color: String }],
+  },
+  generator: { type: String, required: true },
+  formatDetection: {
+    email: { type: Boolean, required: true },
+    address: { type: Boolean, required: true },
+    telephone: { type: Boolean, required: true },
+  },
+  pinterest: {
+    richPin: { type: Boolean, required: true },
+  },
+  category: { type: String, required: true },
+  twitter: {
+    site: { type: String, required: true },
+    creator: { type: String, required: true },
+    images: [{ type: String, required: true }],
+  },
+  openGraph: {
+    url: { type: String, required: true },
+    siteName: { type: String, required: true },
+    locale: { type: String, required: true },
+    type: { type: String, required: true },
+    images: [imageSchema],
+  },
+  authors: [{ name: { type: String, required: true }, url: String }],
+  keywords: [{ type: String, required: true }],
+  description: { type: String, required: true },
+  title: {
+    default: { type: String, required: true },
+  },
+}, { timestamps: true, versionKey: false });
+
+export default mongoose.models.StaticMeta || mongoose.model('StaticMeta', staticMetaSchema);


### PR DESCRIPTION
## Summary
- create `StaticMeta` mongoose model and validation schema
- add API route for getting/updating static meta
- add admin page with editable JSON form for static meta

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d58738aec8328b5e4cdf344f27722