### PR TITLE
Implement lead email attachments

### DIFF
--- a/app/api/v1/admin/leads/route.js
+++ b/app/api/v1/admin/leads/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import connectDB from '@/app/lib/db';
 import Lead, { LEAD_STATUS } from '@/app/models/Lead';
 import { uploadLeadAttachment } from '@/app/middleware/attachmentUpload';
+import { sendLeadEmail } from '@/app/lib/mail';
 
 // GET all leads
 export async function GET() {
@@ -47,6 +48,8 @@ export async function POST(request) {
       attachments,
       status: formData.get('status') && [1,2,3].includes(Number(formData.get('status'))) ? Number(formData.get('status')) : LEAD_STATUS.UPCOMING
     });
+
+    await sendLeadEmail(lead);
     return NextResponse.json({ success: true, message: 'Lead created successfully', data: lead }, { status: 201 });
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Error creating lead' }, { status: 500 });

--- a/app/lib/mail.js
+++ b/app/lib/mail.js
@@ -444,9 +444,9 @@ export async function sendLeadEmail(lead) {
     if (lead.attachments && Array.isArray(lead.attachments)) {
       for (const filename of lead.attachments) {
         try {
-          const buffer = await getObjectBuffer(`uploads/leads/${filename}`);
-          if (buffer) {
-            attachments.push({ filename, content: buffer });
+          const file = await getObjectBuffer(`uploads/leads/${filename}`);
+          if (file && file.buffer) {
+            attachments.push({ filename, content: file.buffer, contentType: file.contentType });
           }
         } catch (err) {
           console.error('Error fetching attachment', filename, err);
@@ -459,15 +459,76 @@ export async function sendLeadEmail(lead) {
       to: process.env.LEADS_NOTIFICATION_EMAIL,
       subject: `New Lead: ${lead.contact_name || lead.email || 'Unknown'}`,
       html: `
-        <p>You have received a new lead via the admin panel.</p>
-        <ul>
-          <li><strong>Name:</strong> ${lead.contact_name || 'N/A'}</li>
-          <li><strong>Email:</strong> ${lead.email || 'N/A'}</li>
-          <li><strong>Mobile:</strong> ${lead.mobile_number || 'N/A'}</li>
-          <li><strong>Organization:</strong> ${lead.organization || 'N/A'}</li>
-          <li><strong>Requirements:</strong> ${lead.requirements || 'N/A'}</li>
-          <li><strong>Description:</strong> ${lead.description || 'N/A'}</li>
-        </ul>
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>New Lead - IMG</title>
+        </head>
+        <body style="margin: 0; padding: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f4f4;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; margin-top: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+            <tr>
+              <td style="padding: 40px 0; text-align: center; background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%); border-radius: 8px 8px 0 0;">
+                <h1 style="color: #ffffff; margin: 0; font-size: 32px;">New Lead Received</h1>
+                <p style="color: #ffffff; margin: 10px 0 0; font-size: 18px;">IMG Admin Panel</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 40px;">
+                <h2 style="color: #1f2937; margin: 0 0 20px; font-size: 20px;">Lead Details</h2>
+                <div style="background: #f8fafc; padding: 20px; border-radius: 8px; margin: 20px 0;">
+                  <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td style="padding: 8px 0;"><strong style="color: #1f2937;">Name:</strong></td>
+                      <td style="padding: 8px 0; color: #4b5563;">${lead.contact_name || 'N/A'}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 8px 0;"><strong style="color: #1f2937;">Email:</strong></td>
+                      <td style="padding: 8px 0; color: #4b5563;">${lead.email || 'N/A'}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 8px 0;"><strong style="color: #1f2937;">Mobile:</strong></td>
+                      <td style="padding: 8px 0; color: #4b5563;">${lead.mobile_number || 'N/A'}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 8px 0;"><strong style="color: #1f2937;">Organization:</strong></td>
+                      <td style="padding: 8px 0; color: #4b5563;">${lead.organization || 'N/A'}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 8px 0;"><strong style="color: #1f2937;">Requirements:</strong></td>
+                      <td style="padding: 8px 0; color: #4b5563;">${lead.requirements || 'N/A'}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 8px 0;"><strong style="color: #1f2937;">Description:</strong></td>
+                      <td style="padding: 8px 0; color: #4b5563;">${lead.description || 'N/A'}</td>
+                    </tr>
+                  </table>
+                </div>
+
+                <p style="color: #4b5563; margin: 20px 0; font-size: 16px;">Any attachments provided are included with this email.</p>
+
+                <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
+
+                <div style="text-align: center;">
+                  <p style="color: #6b7280; margin: 0 0 10px; font-size: 14px;">IMG Global Infotech Pvt Ltd</p>
+                  <p style="color: #6b7280; margin: 0; font-size: 12px;">This is an automated message, please do not reply.</p>
+                  <div style="margin-top: 20px;">
+                    <a href="${process.env.NEXT_PUBLIC_BASE_URL}" style="color: #2563eb; text-decoration: none; font-size: 14px;">Visit IMG</a>
+                    <span style="color: #6b7280; margin: 0 10px;">|</span>
+                    <a href="${process.env.NEXT_PUBLIC_BASE_URL}/contact" style="color: #2563eb; text-decoration: none; font-size: 14px;">Contact Support</a>
+                  </div>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 20px; text-align: center; background: #1f2937; border-radius: 0 0 8px 8px;">
+                <p style="color: #ffffff; margin: 0; font-size: 12px;">&copy; ${new Date().getFullYear()} IMG. All rights reserved.</p>
+              </td>
+            </tr>
+          </table>
+        </body>
+        </html>
       `,
       attachments
     };

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -31,11 +31,11 @@ export async function getObjectBuffer(key) {
   const Bucket = process.env.AWS_S3_BUCKET;
   if (!Bucket) throw new Error('AWS_S3_BUCKET not configured');
   const command = new GetObjectCommand({ Bucket, Key: key });
-  const { Body } = await s3.send(command);
+  const { Body, ContentType } = await s3.send(command);
   if (!Body) return null;
   const chunks = [];
   for await (const chunk of Body) {
     chunks.push(chunk);
   }
-  return Buffer.concat(chunks);
+  return { buffer: Buffer.concat(chunks), contentType: ContentType };
 }

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 
 const s3 = new S3Client({
   region: process.env.AWS_REGION,
@@ -25,4 +25,17 @@ export async function deleteObject(key) {
 export function getPublicUrl(key) {
   const base = process.env.NEXT_PUBLIC_CLOUDFRONT_URL || '';
   return `${base}/${key}`;
+}
+
+export async function getObjectBuffer(key) {
+  const Bucket = process.env.AWS_S3_BUCKET;
+  if (!Bucket) throw new Error('AWS_S3_BUCKET not configured');
+  const command = new GetObjectCommand({ Bucket, Key: key });
+  const { Body } = await s3.send(command);
+  if (!Body) return null;
+  const chunks = [];
+  for await (const chunk of Body) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
 }


### PR DESCRIPTION
## Summary
- support attachments in new lead email
- add helper to download files from S3

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d5aac78348328bee9a414a9949ac8