### PR TITLE
Add schema admin pages and API

### DIFF
--- a/app/(frontend)/page.jsx
+++ b/app/(frontend)/page.jsx
@@ -167,9 +167,9 @@ export const metadata = {
     ]
   }
 
-  const corporationSchema = {
+  const organizationSchema = {
     "@context": "https://schema.org",
-    "@type": "Corporation",
+    "@type": "Organization",
     "name": "IMG Global Infotech Inc.",
     "url": process.env.NEXT_PUBLIC_BASE_URL,
     "logo": "https://d1y41eupgbwbb2.cloudfront.net/images/xl-logo.webp",
@@ -277,7 +277,7 @@ export default function Home() {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(corporationSchema).replace(/</g, '\\u003c'),
+            __html: JSON.stringify(organizationSchema).replace(/</g, '\\u003c'),
           }}
         />
         <script

--- a/app/actions/schemaEntries.js
+++ b/app/actions/schemaEntries.js
@@ -1,0 +1,31 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import SchemaEntry from '@/app/models/SchemaEntry';
+import connectDB from '@/app/lib/db';
+
+export async function createSchemaEntry(data) {
+  try {
+    await connectDB();
+    const entry = await SchemaEntry.create(data);
+    revalidatePath('/admin/schema');
+    return { success: true, data: { ...entry.toObject(), _id: entry._id.toString() } };
+  } catch (error) {
+    console.error('Schema entry creation error:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+export async function updateSchemaEntry(id, data) {
+  try {
+    await connectDB();
+    const entry = await SchemaEntry.findByIdAndUpdate(id, data, { new: true });
+    if (!entry) return { success: false, error: 'Not found' };
+    revalidatePath('/admin/schema');
+    revalidatePath(`/admin/schema/${id}`);
+    return { success: true, data: { ...entry.toObject(), _id: entry._id.toString() } };
+  } catch (error) {
+    console.error('Schema entry update error:', error);
+    return { success: false, error: error.message };
+  }
+}

--- a/app/admin/schema/[slug]/add/page.jsx
+++ b/app/admin/schema/[slug]/add/page.jsx
@@ -332,7 +332,7 @@ export default function Page() {
                   <FormItem>
                     <FormLabel>Contact Phone</FormLabel>
                     <FormControl>
-                      <PhoneInput value={field.value} onChange={field.onChange} />
+                      <PhoneInput value={field.value} onChange={field.onChange} autoFocus />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/app/admin/schema/[slug]/add/page.jsx
+++ b/app/admin/schema/[slug]/add/page.jsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
 import { toast } from "sonner";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import apiFetch from "@/helpers/apiFetch";
 
 const schemaOptions = [
@@ -24,8 +24,8 @@ const schemaOptions = [
 
 export default function Page() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const pageUrl = searchParams.get("url") || "";
+  const { slug } = useParams();
+  const pageUrl = slug === "home" ? "/" : `/${slug}`;
   const [selected, setSelected] = useState("Corporation");
 
   const formSchema = useMemo(() => {

--- a/app/admin/schema/[slug]/add/page.jsx
+++ b/app/admin/schema/[slug]/add/page.jsx
@@ -30,7 +30,7 @@ import { useRouter, useParams } from "next/navigation";
 import apiFetch from "@/helpers/apiFetch";
 
 const schemaOptions = [
-  "Corporation",
+  "Organization",
   "WebPage",
   "LocalBusiness",
   "BreadcrumbList",
@@ -43,20 +43,27 @@ export default function Page() {
   const router = useRouter();
   const { slug } = useParams();
   const pageUrl = slug === "home" ? "/" : `/${slug}`;
-  const [selected, setSelected] = useState("Corporation");
+  const [selected, setSelected] = useState("Organization");
 
   const formSchema = useMemo(() => {
     switch (selected) {
-      case "Corporation":
+      case "Organization":
         return z.object({
-          type: z.literal("Corporation"),
+          type: z.literal("Organization"),
           name: z.string().min(1, "Name is required"),
+          legalName: z.string().optional(),
           url: z.string().url("Invalid URL"),
           logo: z.string().optional(),
           contactEmail: z.string().email("Invalid email").optional(),
           contactPhone: z.string().optional(),
           foundingDate: z.string().optional(),
-          address: z.string().optional(),
+          streetAddress: z.string().optional(),
+          addressLocality: z.string().optional(),
+          addressRegion: z.string().optional(),
+          postalCode: z.string().optional(),
+          addressCountry: z.string().optional(),
+          founders: z.array(z.string()).optional(),
+          areaServed: z.array(z.string()).optional(),
           sameAs: z.array(z.string()).optional()
         });
       case "WebPage":
@@ -123,16 +130,23 @@ export default function Page() {
   }, [selected]);
   const getDefaults = (type) => {
     switch (type) {
-      case "Corporation":
+      case "Organization":
         return {
-          type: "Corporation",
+          type: "Organization",
           name: "",
+          legalName: "",
           url: "",
           logo: "",
           contactEmail: "",
           contactPhone: "",
           foundingDate: "",
-          address: "",
+          streetAddress: "",
+          addressLocality: "",
+          addressRegion: "",
+          postalCode: "",
+          addressCountry: "",
+          founders: [],
+          areaServed: [],
           sameAs: [],
         };
       case "WebPage":
@@ -268,11 +282,18 @@ export default function Page() {
           />
 
           {/* Render dynamic fields */}
-          {selected === "Corporation" && (
+          {selected === "Organization" && (
             <>
               <FormField name="name" control={form.control} render={({ field }) => (
                 <FormItem>
                   <FormLabel>Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="legalName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Legal Name</FormLabel>
                   <FormControl><Input {...field} /></FormControl>
                   <FormMessage />
                 </FormItem>
@@ -330,10 +351,58 @@ export default function Page() {
                   </FormItem>
                 )}
               />
-              <FormField name="address" control={form.control} render={({ field }) => (
+              <FormField name="streetAddress" control={form.control} render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Address</FormLabel>
-                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormLabel>Street Address</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="addressLocality" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>City</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="addressRegion" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Region</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <div className="grid md:grid-cols-2 gap-4">
+                <FormField name="postalCode" control={form.control} render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Postal Code</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+                <FormField name="addressCountry" control={form.control} render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Country Code</FormLabel>
+                    <FormControl><Input {...field} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )} />
+              </div>
+              <FormField name="founders" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Founders</FormLabel>
+                  <FormControl>
+                    <MultiKeywordCombobox value={field.value} onChange={field.onChange} label={null} placeholder="Add founder" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="areaServed" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Area Served</FormLabel>
+                  <FormControl>
+                    <MultiKeywordCombobox value={field.value} onChange={field.onChange} label={null} placeholder="Add code" />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )} />

--- a/app/admin/schema/[slug]/add/page.jsx
+++ b/app/admin/schema/[slug]/add/page.jsx
@@ -2,7 +2,7 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -105,13 +105,88 @@ export default function Page() {
     }
   }, [selected]);
 
+  const defaultValues = useMemo(() => {
+    switch (selected) {
+      case "Corporation":
+        return {
+          type: "Corporation",
+          name: "",
+          url: "",
+          logo: "",
+          contactEmail: "",
+          contactPhone: "",
+          foundingDate: "",
+          address: "",
+          sameAs: "",
+        };
+      case "WebPage":
+        return {
+          type: "WebPage",
+          pageTitle: "",
+          pageDescription: "",
+          pageUrl,
+          datePublished: "",
+          dateModified: "",
+          authorName: "",
+        };
+      case "LocalBusiness":
+        return {
+          type: "LocalBusiness",
+          businessName: "",
+          address: "",
+          openingHours: "",
+          latitude: "",
+          longitude: "",
+          phoneNumber: "",
+          services: "",
+          priceRange: "",
+        };
+      case "BreadcrumbList":
+        return { type: "BreadcrumbList", items: "" };
+      case "Product":
+        return {
+          type: "Product",
+          productName: "",
+          description: "",
+          brandName: "",
+          sku: "",
+          imageUrl: "",
+          price: "",
+          currency: "",
+          availability: "",
+        };
+      case "Service":
+        return {
+          type: "Service",
+          serviceName: "",
+          description: "",
+          areaServed: "",
+          serviceType: "",
+          providerName: "",
+        };
+      case "NewsArticle":
+        return {
+          type: "NewsArticle",
+          headline: "",
+          description: "",
+          authorName: "",
+          datePublished: "",
+          dateModified: "",
+          mainImageUrl: "",
+        };
+      default:
+        return { type: selected };
+    }
+  }, [selected, pageUrl]);
+
   const form = useForm({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      type: selected,
-      pageUrl
-    }
+    defaultValues,
   });
+
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [defaultValues, form]);
 
   async function onSubmit(values) {
     const res = await apiFetch(`/api/v1/admin/schema`, {

--- a/app/admin/schema/[slug]/add/page.jsx
+++ b/app/admin/schema/[slug]/add/page.jsx
@@ -9,8 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { DatePicker } from "@/components/ui/date-picker";
 import ImageCropperInput from "@/components/image-cropper-input";
 import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
-import { PhoneInput } from "react-international-phone";
-import "react-international-phone/style.css";
+import PhoneInput from "@/components/ui/phone-input";
 import {
   Select,
   SelectTrigger,
@@ -308,7 +307,7 @@ export default function Page() {
                   <FormItem>
                     <FormLabel>Contact Phone</FormLabel>
                     <FormControl>
-                      <PhoneInput defaultCountry="IN" value={field.value} onChange={field.onChange} />
+                      <PhoneInput value={field.value} onChange={field.onChange} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -451,7 +450,7 @@ export default function Page() {
                   <FormItem>
                     <FormLabel>Phone Number</FormLabel>
                     <FormControl>
-                      <PhoneInput defaultCountry="IN" value={field.value} onChange={field.onChange} />
+                      <PhoneInput value={field.value} onChange={field.onChange} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/app/admin/schema/[slug]/add/page.jsx
+++ b/app/admin/schema/[slug]/add/page.jsx
@@ -202,9 +202,6 @@ export default function Page() {
     defaultValues,
   });
 
-  useEffect(() => {
-    form.reset(getDefaults(selected));
-  }, [selected]);
 
   const [entryId, setEntryId] = useState(null);
 
@@ -246,7 +243,14 @@ export default function Page() {
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Schema Type</FormLabel>
-                <Select value={selected} onValueChange={(val) => { setSelected(val); field.onChange(val); }}>
+                <Select
+                  value={selected}
+                  onValueChange={(val) => {
+                    setSelected(val);
+                    form.reset(getDefaults(val));
+                    field.onChange(val);
+                  }}
+                >
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Select type" />

--- a/app/admin/schema/add/page.jsx
+++ b/app/admin/schema/add/page.jsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
 import { toast } from "sonner";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import apiFetch from "@/helpers/apiFetch";
 
 const schemaOptions = [
@@ -24,6 +24,8 @@ const schemaOptions = [
 
 export default function Page() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const pageUrl = searchParams.get("url") || "";
   const [selected, setSelected] = useState("Corporation");
 
   const formSchema = useMemo(() => {
@@ -106,14 +108,15 @@ export default function Page() {
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      type: selected
+      type: selected,
+      pageUrl
     }
   });
 
   async function onSubmit(values) {
     const res = await apiFetch(`/api/v1/admin/schema`, {
       method: "POST",
-      data: { type: values.type, data: values }
+      data: { pageUrl, type: values.type, data: values }
     });
     const result = await res.json();
     if (result.success) {

--- a/app/admin/schema/add/page.jsx
+++ b/app/admin/schema/add/page.jsx
@@ -1,0 +1,485 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { useState, useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import apiFetch from "@/helpers/apiFetch";
+
+const schemaOptions = [
+  "Corporation",
+  "WebPage",
+  "LocalBusiness",
+  "BreadcrumbList",
+  "Product",
+  "Service",
+  "NewsArticle"
+];
+
+export default function Page() {
+  const router = useRouter();
+  const [selected, setSelected] = useState("Corporation");
+
+  const formSchema = useMemo(() => {
+    switch (selected) {
+      case "Corporation":
+        return z.object({
+          type: z.literal("Corporation"),
+          name: z.string(),
+          url: z.string().url(),
+          logo: z.string().url().optional(),
+          contactEmail: z.string().email().optional(),
+          contactPhone: z.string().optional(),
+          foundingDate: z.string().optional(),
+          address: z.string().optional(),
+          sameAs: z.array(z.string()).optional()
+        });
+      case "WebPage":
+        return z.object({
+          type: z.literal("WebPage"),
+          pageTitle: z.string(),
+          pageDescription: z.string().optional(),
+          pageUrl: z.string().url(),
+          datePublished: z.string().optional(),
+          dateModified: z.string().optional(),
+          authorName: z.string().optional()
+        });
+      case "LocalBusiness":
+        return z.object({
+          type: z.literal("LocalBusiness"),
+          businessName: z.string(),
+          address: z.string().optional(),
+          openingHours: z.string().optional(),
+          latitude: z.number().optional(),
+          longitude: z.number().optional(),
+          phoneNumber: z.string().optional(),
+          services: z.array(z.string()).optional(),
+          priceRange: z.string().optional()
+        });
+      case "BreadcrumbList":
+        return z.object({
+          type: z.literal("BreadcrumbList"),
+          items: z.string()
+        });
+      case "Product":
+        return z.object({
+          type: z.literal("Product"),
+          productName: z.string(),
+          description: z.string().optional(),
+          brandName: z.string().optional(),
+          sku: z.string().optional(),
+          imageUrl: z.string().url().optional(),
+          price: z.number().optional(),
+          currency: z.string().optional(),
+          availability: z.string().optional()
+        });
+      case "Service":
+        return z.object({
+          type: z.literal("Service"),
+          serviceName: z.string(),
+          description: z.string().optional(),
+          areaServed: z.string().optional(),
+          serviceType: z.string().optional(),
+          providerName: z.string().optional()
+        });
+      case "NewsArticle":
+        return z.object({
+          type: z.literal("NewsArticle"),
+          headline: z.string(),
+          description: z.string().optional(),
+          authorName: z.string().optional(),
+          datePublished: z.string().optional(),
+          dateModified: z.string().optional(),
+          mainImageUrl: z.string().url().optional()
+        });
+      default:
+        return z.object({ type: z.string() });
+    }
+  }, [selected]);
+
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      type: selected
+    }
+  });
+
+  async function onSubmit(values) {
+    const res = await apiFetch(`/api/v1/admin/schema`, {
+      method: "POST",
+      data: { type: values.type, data: values }
+    });
+    const result = await res.json();
+    if (result.success) {
+      toast.success("Created");
+      router.push("/admin/schema");
+      router.refresh();
+    } else {
+      toast.error(result.error || "Failed");
+    }
+  }
+
+  return (
+    <div className="w-full p-4 space-y-6">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="type"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Schema Type</FormLabel>
+                <Select value={selected} onValueChange={(val) => { setSelected(val); field.onChange(val); }}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {schemaOptions.map((op) => (
+                      <SelectItem key={op} value={op}>{op}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Render dynamic fields */}
+          {selected === "Corporation" && (
+            <>
+              <FormField name="name" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="url" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>URL</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="logo" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Logo URL</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="contactEmail" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Contact Email</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="contactPhone" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Contact Phone</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="foundingDate" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Founding Date</FormLabel>
+                  <FormControl><Input type="date" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="address" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Address</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="sameAs" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>SameAs Links (comma separated)</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+            </>
+          )}
+          {selected === "WebPage" && (
+            <>
+              <FormField name="pageTitle" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Page Title</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="pageDescription" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Page Description</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="pageUrl" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Page URL</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="datePublished" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Date Published</FormLabel>
+                  <FormControl><Input type="date" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="dateModified" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Date Modified</FormLabel>
+                  <FormControl><Input type="date" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="authorName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Author Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+            </>
+          )}
+          {selected === "LocalBusiness" && (
+            <>
+              <FormField name="businessName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Business Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="address" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Address</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="openingHours" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Opening Hours</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="latitude" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Latitude</FormLabel>
+                  <FormControl><Input type="number" step="any" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="longitude" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Longitude</FormLabel>
+                  <FormControl><Input type="number" step="any" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="phoneNumber" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Phone Number</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="services" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Services Offered (comma separated)</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="priceRange" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Price Range</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+            </>
+          )}
+          {selected === "BreadcrumbList" && (
+            <FormField name="items" control={form.control} render={({ field }) => (
+              <FormItem>
+                <FormLabel>Breadcrumb Items (JSON)</FormLabel>
+                <FormControl><Textarea {...field} /></FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+          )}
+          {selected === "Product" && (
+            <>
+              <FormField name="productName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Product Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="description" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="brandName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Brand Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="sku" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>SKU</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="imageUrl" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Image URL</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="price" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Price</FormLabel>
+                  <FormControl><Input type="number" step="any" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="currency" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Currency</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="availability" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Availability</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+            </>
+          )}
+          {selected === "Service" && (
+            <>
+              <FormField name="serviceName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Service Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="description" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="areaServed" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Area Served</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="serviceType" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Service Type</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="providerName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Provider Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+            </>
+          )}
+          {selected === "NewsArticle" && (
+            <>
+              <FormField name="headline" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Headline</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="description" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl><Textarea {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="authorName" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Author Name</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="datePublished" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Date Published</FormLabel>
+                  <FormControl><Input type="date" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="dateModified" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Date Modified</FormLabel>
+                  <FormControl><Input type="date" {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+              <FormField name="mainImageUrl" control={form.control} render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Main Image URL</FormLabel>
+                  <FormControl><Input {...field} /></FormControl>
+                  <FormMessage />
+                </FormItem>
+              )} />
+            </>
+          )}
+          <div className="flex justify-end pt-4">
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/app/admin/schema/page.jsx
+++ b/app/admin/schema/page.jsx
@@ -1,33 +1,17 @@
-import Link from 'next/link';
-import { ArrowRight } from 'lucide-react';
+import { SchemaPageTable } from '@/components/schemaPageTable';
 
-async function getSchemaEntries() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/schema`);
+async function getPages() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/pages`, { cache: 'no-store' });
   const json = await res.json();
   return Array.isArray(json.data) ? json.data : [];
 }
 
 export default async function Page() {
-  const entries = await getSchemaEntries();
+  const pages = await getPages();
+  const data = pages.map(url => ({ url }));
   return (
-    <div className="w-full p-4 space-y-4">
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">Schema Entries</h2>
-        <Link href="/admin/schema/add" className="flex items-center gap-2 text-sm font-medium">
-          Add New <ArrowRight size={16} />
-        </Link>
-      </div>
-      <div className="grid gap-4">
-        {entries.map((e) => (
-          <div key={e._id} className="border p-4 rounded-md">
-            <div className="font-semibold">{e.type}</div>
-            <pre className="whitespace-pre-wrap text-xs mt-2 bg-muted p-2 rounded">
-              {JSON.stringify(e.data, null, 2)}
-            </pre>
-          </div>
-        ))}
-        {entries.length === 0 && <p>No entries found.</p>}
-      </div>
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <SchemaPageTable data={data} />
     </div>
   );
 }

--- a/app/admin/schema/page.jsx
+++ b/app/admin/schema/page.jsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+async function getSchemaEntries() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/schema`);
+  const json = await res.json();
+  return Array.isArray(json.data) ? json.data : [];
+}
+
+export default async function Page() {
+  const entries = await getSchemaEntries();
+  return (
+    <div className="w-full p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">Schema Entries</h2>
+        <Link href="/admin/schema/add" className="flex items-center gap-2 text-sm font-medium">
+          Add New <ArrowRight size={16} />
+        </Link>
+      </div>
+      <div className="grid gap-4">
+        {entries.map((e) => (
+          <div key={e._id} className="border p-4 rounded-md">
+            <div className="font-semibold">{e.type}</div>
+            <pre className="whitespace-pre-wrap text-xs mt-2 bg-muted p-2 rounded">
+              {JSON.stringify(e.data, null, 2)}
+            </pre>
+          </div>
+        ))}
+        {entries.length === 0 && <p>No entries found.</p>}
+      </div>
+    </div>
+  );
+}

--- a/app/api/v1/admin/pages/route.js
+++ b/app/api/v1/admin/pages/route.js
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { readdir } from 'fs/promises';
+import path from 'path';
+
+export async function GET() {
+  try {
+    const baseDir = path.join(process.cwd(), 'app/(frontend)');
+    const entries = await readdir(baseDir, { withFileTypes: true });
+    const pages = ['/', ...entries.filter(e => e.isDirectory()).map(e => {
+      const name = e.name.replace(/\.php$/, '');
+      return `/${name}`;
+    })];
+    return NextResponse.json({ success: true, data: pages });
+  } catch (error) {
+    console.error('Error listing pages:', error);
+    return NextResponse.json({ success: false, error: 'Error listing pages' }, { status: 500 });
+  }
+}
+

--- a/app/api/v1/admin/schema/[id]/route.js
+++ b/app/api/v1/admin/schema/[id]/route.js
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import SchemaEntry from '@/app/models/SchemaEntry';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function GET(request, { params }) {
+  try {
+    await connectDB();
+    const entry = await SchemaEntry.findById(params.id).lean();
+    if (!entry) {
+      return NextResponse.json({ success: false, error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: entry });
+  } catch (error) {
+    console.error('Error fetching schema entry:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching schema entry' }, { status: 500 });
+  }
+}
+
+export async function PUT(request, { params }) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+    await connectDB();
+    const body = await request.json();
+    const entry = await SchemaEntry.findByIdAndUpdate(
+      params.id,
+      { type: body.type, data: body.data },
+      { new: true }
+    );
+    if (!entry) {
+      return NextResponse.json({ success: false, error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true, data: entry });
+  } catch (error) {
+    console.error('Error updating schema entry:', error);
+    return NextResponse.json({ success: false, error: 'Error updating schema entry' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+    await connectDB();
+    const entry = await SchemaEntry.findByIdAndDelete(params.id);
+    if (!entry) {
+      return NextResponse.json({ success: false, error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting schema entry:', error);
+    return NextResponse.json({ success: false, error: 'Error deleting schema entry' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/schema/[id]/route.js
+++ b/app/api/v1/admin/schema/[id]/route.js
@@ -31,7 +31,7 @@ export async function PUT(request, { params }) {
     const body = await request.json();
     const entry = await SchemaEntry.findByIdAndUpdate(
       params.id,
-      { type: body.type, data: body.data },
+      { pageUrl: body.pageUrl, type: body.type, data: body.data },
       { new: true }
     );
     if (!entry) {

--- a/app/api/v1/admin/schema/route.js
+++ b/app/api/v1/admin/schema/route.js
@@ -6,6 +6,15 @@ import { verifyToken, extractToken } from '@/app/lib/auth';
 export async function GET(request) {
   try {
     await connectDB();
+    const { searchParams } = new URL(request.url);
+    const pageUrl = searchParams.get('pageUrl');
+    if (pageUrl) {
+      const entry = await SchemaEntry.findOne({ pageUrl }).lean();
+      if (!entry) {
+        return NextResponse.json({ success: true, data: null });
+      }
+      return NextResponse.json({ success: true, data: entry });
+    }
     const entries = await SchemaEntry.find().sort({ created_date: -1 }).lean();
     return NextResponse.json({ success: true, data: entries });
   } catch (error) {
@@ -35,5 +44,32 @@ export async function POST(request) {
   } catch (error) {
     console.error('Error creating schema entry:', error);
     return NextResponse.json({ success: false, error: 'Error creating schema entry' }, { status: 500 });
+  }
+}
+
+export async function PUT(request) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+    await connectDB();
+    const body = await request.json();
+    if (!body.type || !body.data || !body.pageUrl) {
+      return NextResponse.json({ success: false, error: 'Missing type, data or pageUrl' }, { status: 400 });
+    }
+    const entry = await SchemaEntry.findOneAndUpdate(
+      { pageUrl: body.pageUrl },
+      { pageUrl: body.pageUrl, type: body.type, data: body.data },
+      { new: true, upsert: true }
+    );
+    return NextResponse.json({ success: true, data: entry });
+  } catch (error) {
+    console.error('Error updating schema entry:', error);
+    return NextResponse.json({ success: false, error: 'Error updating schema entry' }, { status: 500 });
   }
 }

--- a/app/api/v1/admin/schema/route.js
+++ b/app/api/v1/admin/schema/route.js
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import SchemaEntry from '@/app/models/SchemaEntry';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function GET(request) {
+  try {
+    await connectDB();
+    const entries = await SchemaEntry.find().sort({ created_date: -1 }).lean();
+    return NextResponse.json({ success: true, data: entries });
+  } catch (error) {
+    console.error('Error fetching schema entries:', error);
+    return NextResponse.json({ success: false, error: 'Error fetching schema entries' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+
+    await connectDB();
+    const body = await request.json();
+    if (!body.type || !body.data) {
+      return NextResponse.json({ success: false, error: 'Missing type or data' }, { status: 400 });
+    }
+    const entry = await SchemaEntry.create({ type: body.type, data: body.data });
+    return NextResponse.json({ success: true, data: entry }, { status: 201 });
+  } catch (error) {
+    console.error('Error creating schema entry:', error);
+    return NextResponse.json({ success: false, error: 'Error creating schema entry' }, { status: 500 });
+  }
+}

--- a/app/api/v1/admin/schema/route.js
+++ b/app/api/v1/admin/schema/route.js
@@ -27,10 +27,10 @@ export async function POST(request) {
 
     await connectDB();
     const body = await request.json();
-    if (!body.type || !body.data) {
-      return NextResponse.json({ success: false, error: 'Missing type or data' }, { status: 400 });
+    if (!body.type || !body.data || !body.pageUrl) {
+      return NextResponse.json({ success: false, error: 'Missing type, data or pageUrl' }, { status: 400 });
     }
-    const entry = await SchemaEntry.create({ type: body.type, data: body.data });
+    const entry = await SchemaEntry.create({ pageUrl: body.pageUrl, type: body.type, data: body.data });
     return NextResponse.json({ success: true, data: entry }, { status: 201 });
   } catch (error) {
     console.error('Error creating schema entry:', error);

--- a/app/models/SchemaEntry.js
+++ b/app/models/SchemaEntry.js
@@ -6,7 +6,7 @@ const schemaEntrySchema = new mongoose.Schema(
       type: String,
       required: true,
       enum: [
-        'Corporation',
+        'Organization',
         'WebPage',
         'LocalBusiness',
         'BreadcrumbList',

--- a/app/models/SchemaEntry.js
+++ b/app/models/SchemaEntry.js
@@ -15,6 +15,10 @@ const schemaEntrySchema = new mongoose.Schema(
         'NewsArticle'
       ]
     },
+    pageUrl: {
+      type: String,
+      required: true
+    },
     data: {
       type: mongoose.Schema.Types.Mixed,
       required: true

--- a/app/models/SchemaEntry.js
+++ b/app/models/SchemaEntry.js
@@ -1,0 +1,38 @@
+import mongoose from 'mongoose';
+
+const schemaEntrySchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      required: true,
+      enum: [
+        'Corporation',
+        'WebPage',
+        'LocalBusiness',
+        'BreadcrumbList',
+        'Product',
+        'Service',
+        'NewsArticle'
+      ]
+    },
+    data: {
+      type: mongoose.Schema.Types.Mixed,
+      required: true
+    },
+    created_date: {
+      type: Date,
+      default: Date.now
+    },
+    modified_date: {
+      type: Date,
+      default: Date.now
+    }
+  },
+  {
+    timestamps: { createdAt: 'created_date', updatedAt: 'modified_date' }
+  }
+);
+
+const SchemaEntry = mongoose.models.SchemaEntry || mongoose.model('SchemaEntry', schemaEntrySchema);
+
+export default SchemaEntry;

--- a/components/app-sidebar.jsx
+++ b/components/app-sidebar.jsx
@@ -233,16 +233,12 @@ const data = {
       team: "Meta & Schema",
       items: [
         {
-          title: "Corporation",
-          url: "/admin/schemas/corporation",
+          title: "Organization",
+          url: "/admin/schemas/organization",
         },
         {
           title: "WebPage",
           url: "/admin/schemas/webpage",
-        },
-        {
-          title: "Organization",
-          url: "/admin/schemas/organization",
         },
         {
           title: "LocalBusiness",

--- a/components/schemaPageTable.jsx
+++ b/components/schemaPageTable.jsx
@@ -1,0 +1,143 @@
+"use client";
+import * as React from "react";
+import {
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import Link from "next/link";
+
+function PageActions({ page }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-8 w-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem asChild>
+          <Link href={`/admin/faqs/add?url=${encodeURIComponent(page.url)}`}>Add FAQ</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href={`/admin/schema/add?url=${encodeURIComponent(page.url)}`}>Add Schema</Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export const columns = [
+  {
+    accessorKey: "url",
+    header: "URL",
+    cell: ({ row }) => <span className="font-mono text-xs">{row.getValue("url")}</span>,
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => <PageActions page={row.original} />,
+  },
+];
+
+export function SchemaPageTable({ data }) {
+  const [filter, setFilter] = React.useState("");
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      globalFilter: filter,
+    },
+    onGlobalFilterChange: setFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  return (
+    <div className="w-full">
+      <div className="flex gap-3 items-center py-4">
+        <Input
+          placeholder="Filter by url..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="max-w-sm"
+        />
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/schemaPageTable.jsx
+++ b/components/schemaPageTable.jsx
@@ -41,7 +41,9 @@ function PageActions({ page }) {
           <Link href={`/admin/faqs/add?url=${encodeURIComponent(page.url)}`}>Add FAQ</Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link href={`/admin/schema/add?url=${encodeURIComponent(page.url)}`}>Add Schema</Link>
+          <Link href={`/admin/schema/${page.url === '/' ? 'home' : page.url.substring(1)}/add`}>
+            Add Schema
+          </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/components/ui/phone-input.jsx
+++ b/components/ui/phone-input.jsx
@@ -1,0 +1,37 @@
+"use client";
+import { useEffect, useState } from "react";
+import { PhoneInput } from "react-international-phone";
+import "react-international-phone/style.css";
+
+export default function PhoneInputWrapper({ value, onChange, className = "", ...props }) {
+  const [country, setCountry] = useState("in");
+
+  useEffect(() => {
+    fetch("https://ipinfo.io/json")
+      .then(res => res.json())
+      .then(data => {
+        if (data && data.country) setCountry(data.country.toLowerCase());
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <PhoneInput
+      {...props}
+      defaultCountry={country}
+      preferredCountries={["in", "us"]}
+      value={value}
+      onChange={onChange}
+      className={`w-full ${className}`}
+      inputClassName="w-full bg-transparent h-9 px-3 py-2 border rounded-md text-sm focus-visible:outline-none focus-visible:ring-ring/50"
+      countrySelectorStyleProps={{
+        buttonClassName: "border-r border-input px-2 py-1 bg-transparent",
+        dropdownStyleProps: {
+          className: "bg-popover text-popover-foreground border rounded-md shadow-md max-h-60 overflow-y-auto",
+          listItemClassName: "px-2 py-1.5 text-sm cursor-pointer hover:bg-accent flex gap-2 items-center",
+          preferredListDividerClassName: "my-1 border-t"
+        }
+      }}
+    />
+  );
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.58.0",
     "react-hotkeys-hook": "^5.1.0",
+    "react-international-phone": "4.5.0",
     "react-intersection-observer": "^9.16.0",
     "react-resizable-panels": "^3.0.2",
     "sharp": "^0.34.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.58.0",
     "react-hotkeys-hook": "^5.1.0",
-    "react-international-phone": "4.5.0",
+    "react-international-phone": "^4.5.0",
     "react-intersection-observer": "^9.16.0",
     "react-resizable-panels": "^3.0.2",
     "sharp": "^0.34.2",


### PR DESCRIPTION
## Summary
- add `SchemaEntry` model for storing structured data
- create API routes for CRUD operations on schema entries
- implement server actions to handle schema entry creation and update
- add admin UI to create schema entries with dynamic fields and list entries

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d935024b08328b7b42d181f4e01d7