### PR TITLE
Apply static meta API in layout

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -8,125 +8,52 @@ const poppins = Poppins({
   subsets: ["latin"],
 });
 
-export const metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL),
-  title: {
-    default: 'Mobile App Development & IT Consulting Services in USA | IMG Global Infotech',
-    template: '%s',
-  },
-  description: 'IMG Global Infotech is a top mobile app development company in USA, UK, UAE, and India, providing expert IT consulting services for startups to large enterprises.',
-  keywords: [
-    'Mobile App Development',
-    'IT Consulting',
-    'Software Development',
-    'USA',
-    'UK',
-    'UAE',
-    'India',
-    'IMG Global Infotech',
-  ],
-  authors: [
-    { name: 'Mr. Mohit Mittal' },
-    { name: 'IMG Global Infotech', url: process.env.NEXT_PUBLIC_BASE_URL },
-  ],
-  creator: 'IMG Global Infotech',
-  publisher: 'IMG Global Infotech',
-  formatDetection: {
-    email: false,
-    address: false,
-    telephone: false,
-  },
-  robots: {
-    index: process.env.NODE_ENV === 'production',
-    follow: process.env.NODE_ENV === 'production',
-    nocache: false,
-    googleBot: {
-      index: process.env.NODE_ENV === 'production',
-      follow: process.env.NODE_ENV === 'production',
-      noimageindex: process.env.NODE_ENV === 'production',
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
-    },
-  },
-  generator: 'Next.js 15.3.3 + Tailwind CSS',
-  applicationName: 'IMG Global Infotech',
-  referrer: 'origin-when-cross-origin',
-  manifest: '/site.webmanifest',
-  openGraph: {
-    title:
-      'IMG Global Infotech | Mobile App Development & IT Consulting Agency in USA, UK, UAE & India',
-    description:
-      'IMG Global Infotech is the best IT consulting Company that provides the best IT consulting services to startups, mid-size, medium-size and large-size businesses.',
-    url: process.env.NEXT_PUBLIC_BASE_URL,
-    siteName: 'IMG Global Infotech',
-    locale: 'en_US',
-    type: 'website',
-    images: [
-      {
-        url: '/android-chrome-192x192.png',
-        width: 1200,
-        height: 630,
-        alt: 'IMG Global Infotech',
-        type: 'image/jpg',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'IMG Global Infotech | Mobile App Development & IT Consulting Agency in USA, UK, UAE & India',
-    description: 'IMG Global Infotech is the best IT consulting Company that provides the best IT consulting services to startups, mid-size, medium-size and large-size businesses.',
-    site: '@imgglobal',
-    creator: '@imgglobal',
-    images: ['/android-chrome-192x192.png'],
-  },
-  icons: {
-    icon: [
-      { url: '/favicon-32x32.png', sizes: '32x32' },
-      { url: '/favicon-16x16.png', sizes: '16x16' },
-    ],
-    shortcut: '/favicon.ico',
-    apple: '/apple-touch-icon.png',
-    other: [
-      {
-        rel: 'mask-icon',
-        url: '/safari-pinned-tab.svg',
-        color: '#000019',
-      },
-      {
-        rel: 'apple-touch-icon-precomposed',
-        url: '/apple-touch-icon.png',
-      },
-    ],
-  },
-  verification: {
-    google: process.env.NODE_ENV === 'production'
-      ? 'bGEWH2c3JpZuiXFhSZGexm_7YdIzsPNhH2w7k6Buk-Q'
-      : 'b3JyKKuxkNseCK4ci5FbXB7AQnSW5jFjBkdW22XWmsc',
-    microsoft: process.env.NODE_ENV === 'production'
-      ? '1CF4AABD4C8EFCCFAFF1458BE10E8FC8'
-      : '',
-    other: {
-      fb: '151060611741013',
-    },
-  },
-  appleWebApp: {
-    title: 'IMG Global Infotech',
-    statusBarStyle: 'black-translucent',
-    capable: true,
-    startupImage: [
-      '/apple-touch-startup-image-768x1004.png',
-      {
-        url: '/apple-touch-startup-image-1536x2008.png',
-        media: '(device-width: 768px) and (device-height: 1024px)',
-      },
-    ],
-  },
-  category: 'technology',
-  pinterest: {
-    richPin: true,
-  },
-};
+export async function generateMetadata() {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/static`);
+    const json = await res.json();
+    const meta = json?.data;
+    if (meta) {
+      const toUrl = (name) =>
+        name && !name.startsWith('http')
+          ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${name}`
+          : name;
+      meta.appleWebApp.startupImage.mainImageUrl = toUrl(
+        meta.appleWebApp.startupImage.mainImageUrl
+      );
+      meta.appleWebApp.startupImage.url = toUrl(meta.appleWebApp.startupImage.url);
+      meta.icons.icon = meta.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }));
+      meta.icons.shortcut = toUrl(meta.icons.shortcut);
+      meta.icons.apple = toUrl(meta.icons.apple);
+      meta.icons.other = meta.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }));
+      meta.twitter.images = meta.twitter.images.map(toUrl);
+      meta.openGraph.images = meta.openGraph.images.map((img) => ({ ...img, url: toUrl(img.url) }));
+
+      return {
+        metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL),
+        referrer: 'origin-when-cross-origin',
+        manifest: '/site.webmanifest',
+        robots: {
+          index: process.env.NODE_ENV === 'production',
+          follow: process.env.NODE_ENV === 'production',
+          nocache: false,
+          googleBot: {
+            index: process.env.NODE_ENV === 'production',
+            follow: process.env.NODE_ENV === 'production',
+            noimageindex: process.env.NODE_ENV === 'production',
+            'max-video-preview': -1,
+            'max-image-preview': 'large',
+            'max-snippet': -1,
+          },
+        },
+        ...meta,
+      };
+    }
+  } catch (err) {
+    console.error('Error fetching static meta:', err);
+  }
+  return {};
+}
 
 export const viewport = {
   themeColor: '#000019',


### PR DESCRIPTION
## Summary
- fetch sitewide metadata from `/api/v1/admin/meta/static`
- remove hardcoded meta values in `app/layout.jsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9d2552b08328b2d39f2cd7b91f76