### PR TITLE
Add FAQs support for blog posts

### DIFF
--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -22,7 +22,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Check, ChevronsUpDown, X } from "lucide-react";
+import { Check, ChevronsUpDown, X, Plus, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import {
@@ -44,7 +44,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { DatePicker } from "@/components/ui/date-picker";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { useForm, useFieldArray } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
@@ -54,6 +54,17 @@ import { useSearchParams, useRouter } from "next/navigation";
 import Loader from "@/components/ui/loader";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import TinyMCEEditor from "@/components/TinyMCEEditor";
+
+const faqEditorInit = {
+  menubar: false,
+  menu: false,
+  plugins: ["lists", "link"],
+  toolbar: "bold italic underline strikethrough | bullist numlist | link",
+  quickbars_selection_toolbar: false,
+  contextmenu: false,
+  valid_elements: "p,strong/b,em/i,u,strike,ul,ol,li,br,a,a[href|target=_blank]",
+  paste_as_text: true,
+};
 
 // Helper to check if image is present (File or preview URL)
 function isImagePresent(val) {
@@ -94,6 +105,7 @@ function getBlogFormSchema(status, bgColorStatus) {
       metaOgDescription: z.string().optional(),
       metaXTitle: z.string().optional(),
       metaXDescription: z.string().optional(),
+      faqs: z.array(z.object({ question: z.string().optional(), answer: z.string().optional() })).optional(),
       status: z.string().default("1"),
       publishedDateTime: z.string().optional(),
       bgColorStatus: z.boolean().default(false),
@@ -122,6 +134,7 @@ function getBlogFormSchema(status, bgColorStatus) {
       metaOgDescription: z.string().min(10, { message: "Meta OG description must be at least 10 characters" }).max(500),
       metaXTitle: z.string().min(2, { message: "Meta X title must be at least 2 characters" }).max(200),
       metaXDescription: z.string().min(10, { message: "Meta X description must be at least 10 characters" }).max(500),
+      faqs: z.array(z.object({ question: z.string().min(1, "Question is required"), answer: z.string().min(1, "Answer is required") })).optional(),
       status: z.string().default("1"),
       publishedDateTime: z.string().min(1, { message: "Published date & time is required" }),
       bgColorStatus: z.boolean().default(false),
@@ -150,6 +163,7 @@ function getBlogFormSchema(status, bgColorStatus) {
       metaOgDescription: z.string().min(10, { message: "Meta OG description must be at least 10 characters" }).max(500),
       metaXTitle: z.string().min(2, { message: "Meta X title must be at least 2 characters" }).max(200),
       metaXDescription: z.string().min(10, { message: "Meta X description must be at least 10 characters" }).max(500),
+      faqs: z.array(z.object({ question: z.string().min(1, "Question is required"), answer: z.string().min(1, "Answer is required") })).optional(),
       status: z.string().default("1"),
       publishedDateTime: z.string().optional(),
       bgColorStatus: z.boolean().default(false),
@@ -198,12 +212,14 @@ function BlogAdd() {
       metaOgDescription: "",
       metaXTitle: "",
       metaXDescription: "",
+      faqs: [{ question: "", answer: "" }],
       status: "1",
       publishedDateTime: "",
       bgColorStatus: false,
       bgColor: "",
     },
   });
+  const faqFields = useFieldArray({ control: form.control, name: "faqs" });
 
   // Watch bgColorStatus and update state
   useEffect(() => {
@@ -287,6 +303,7 @@ function BlogAdd() {
           metaOgDescription: blog.meta_og_description || "",
           metaXTitle: blog.meta_x_title || "",
           metaXDescription: blog.meta_x_description || "",
+          faqs: Array.isArray(blog.faqs) && blog.faqs.length ? blog.faqs : [{ question: "", answer: "" }],
           status: String(blog.status ?? 1),
           publishedDateTime: blog.published_date_time ? new Date(blog.published_date_time).toISOString().slice(0, 16) : "",
           bgColorStatus: blog.bg_color_status ?? false,
@@ -327,6 +344,7 @@ function BlogAdd() {
       if (!isDraft || data.metaOgDescription !== undefined) formData.append("metaOgDescription", data.metaOgDescription || "");
       if (!isDraft || data.metaXTitle !== undefined) formData.append("metaXTitle", data.metaXTitle || "");
       if (!isDraft || data.metaXDescription !== undefined) formData.append("metaXDescription", data.metaXDescription || "");
+      if (data.faqs && data.faqs.length) formData.append("faqs", JSON.stringify(data.faqs));
       // Always send status as number
       formData.append("status", Number(data.status));
       if (data.publishedDateTime !== undefined) formData.append("publishedDateTime", data.publishedDateTime || "");
@@ -412,6 +430,10 @@ function BlogAdd() {
           // Only append if not empty string/null/undefined
           if (value && value !== "") {
             formData.append(key, value);
+          }
+        } else if (key === "faqs") {
+          if (value && value.length) {
+            formData.append(key, JSON.stringify(value));
           }
         } else if (Array.isArray(value)) {
           // For array fields (like metaKeyword), send as comma string if not empty
@@ -948,8 +970,48 @@ function BlogAdd() {
                           </FormItem>
                         )}
                       />
-                    </div> 
-                    <Separator className="my-6" />                 
+                    </div>
+                    <div className="w-full px-3 space-y-4">
+                      {faqFields.fields.map((field, index) => (
+                        <div key={field.id} className="border p-4 rounded-md space-y-4">
+                          <div className="flex flex-wrap">
+                            <FormField
+                              control={form.control}
+                              name={`faqs.${index}.question`}
+                              render={({ field }) => (
+                                <FormItem className="grow mr-4">
+                                  <FormLabel>Question</FormLabel>
+                                  <FormControl>
+                                    <Input {...field} />
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                            <Button type="button" variant="outline" size="icon" className="mt-[22px] cursor-pointer" onClick={() => faqFields.remove(index)}>
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                          <FormField
+                            control={form.control}
+                            name={`faqs.${index}.answer`}
+                            render={({ field }) => (
+                              <FormItem className="[&_.tox-statusbar]:!hidden">
+                                <FormLabel>Answer</FormLabel>
+                                <FormControl>
+                                  <TinyMCEEditor value={field.value} onChange={field.onChange} init={faqEditorInit} />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </div>
+                      ))}
+                      <Button type="button" variant="secondary" size="sm" onClick={() => faqFields.append({ question: '', answer: '' })}>
+                        <Plus className="h-4 w-4 mr-2" /> Add FAQ
+                      </Button>
+                    </div>
+                    <Separator className="my-6" />
                     <div className="md:w-1/3 w-full px-3">
                       <FormField
                         control={form.control}

--- a/app/api/v1/admin/blogs/[id]/route.js
+++ b/app/api/v1/admin/blogs/[id]/route.js
@@ -145,6 +145,15 @@ export async function PUT(request, { params }) {
         .filter((k) => k);
     }
 
+    const faqsString = formData.get('faqs');
+    if (faqsString !== null) {
+      try {
+        blog.faqs = faqsString ? JSON.parse(faqsString) : [];
+      } catch {
+        return NextResponse.json({ success: false, error: 'Invalid FAQs format' }, { status: 400 });
+      }
+    }
+
     const fields = {
       category: 'category',
       title: 'title',

--- a/app/api/v1/admin/blogs/route.js
+++ b/app/api/v1/admin/blogs/route.js
@@ -142,6 +142,16 @@ export async function POST(request) {
       .map((k) => k.trim())
       .filter((k) => k);
 
+    let faqs = [];
+    const faqsString = formData.get('faqs');
+    if (faqsString) {
+      try {
+        faqs = JSON.parse(faqsString);
+      } catch {
+        return NextResponse.json({ success: false, error: 'Invalid FAQs format' }, { status: 400 });
+      }
+    }
+
     const blogData = {
       category: formData.get('category'),
       title: formData.get('title'),
@@ -164,6 +174,7 @@ export async function POST(request) {
       meta_og_description: formData.get('metaOgDescription'),
       meta_x_title: formData.get('metaXTitle'),
       meta_x_description: formData.get('metaXDescription'),
+      faqs,
       status: statusValue,
       published_date_time: formData.get('publishedDateTime') ? new Date(formData.get('publishedDateTime')) : null,
       bg_color_status: formData.get('bgColorStatus') === 'true',

--- a/app/models/Blog.js
+++ b/app/models/Blog.js
@@ -100,6 +100,12 @@ const blogSchema = new mongoose.Schema(
       type: String,
       required: function() { return this.status !== 1; },
     },
+    faqs: [
+      {
+        question: String,
+        answer: String
+      }
+    ],
     published_date_time: Date,
     bg_color_status: {
       type: Boolean,


### PR DESCRIPTION
## Summary
- extend Blog model with `faqs` array
- allow creating/updating FAQs in blog admin API
- support FAQs in blog add/edit forms with dynamic fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685fe7a21838832881da368a5a19468f