### PR TITLE
Add Firebase push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ First, run the development server:
 
 ```bash
 npm run dev
+# or to run over HTTPS for features like push notifications
+npm run dev:https
 # or
 yarn dev
 # or

--- a/app/(frontend)/layout.jsx
+++ b/app/(frontend)/layout.jsx
@@ -3,7 +3,6 @@ import Footer from "@/components/Footer";
 import LeadPopup from "@/components/leadPopup";
 import TawkToWidget from "@/components/TawkToWidget";
 import PageSchema from "@/components/page-schema";
-import FCMInit from "@/components/FCMInit";
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import schemaToLd from "@/helpers/schemaToLd";
@@ -60,7 +59,6 @@ export default async function RootLayout({ children }) {
         <main>
         {children}
         </main>
-        <FCMInit />
         <LeadPopup/>
         <Footer/>
         {isProd && (

--- a/app/(frontend)/layout.jsx
+++ b/app/(frontend)/layout.jsx
@@ -3,6 +3,7 @@ import Footer from "@/components/Footer";
 import LeadPopup from "@/components/leadPopup";
 import TawkToWidget from "@/components/TawkToWidget";
 import PageSchema from "@/components/page-schema";
+import FCMInit from "@/components/FCMInit";
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import schemaToLd from "@/helpers/schemaToLd";
@@ -59,6 +60,7 @@ export default async function RootLayout({ children }) {
         <main>
         {children}
         </main>
+        <FCMInit />
         <LeadPopup/>
         <Footer/>
         {isProd && (

--- a/app/api/v1/admin/blogs/[id]/route.js
+++ b/app/api/v1/admin/blogs/[id]/route.js
@@ -188,7 +188,17 @@ export async function PUT(request, { params }) {
       }
     }
 
+    const wasPublished = blog.isModified('status') && blog.status === 2;
     await blog.save();
+
+    if (wasPublished) {
+      const { sendPushNotification } = await import('@/app/lib/push');
+      await sendPushNotification({
+        title: 'New Blog Published',
+        body: blog.title,
+        data: { blogId: String(blog._id) }
+      });
+    }
 
     return NextResponse.json({ success: true, data: blog });
   } catch (error) {

--- a/app/api/v1/admin/blogs/route.js
+++ b/app/api/v1/admin/blogs/route.js
@@ -183,6 +183,15 @@ export async function POST(request) {
 
     const blog = await Blog.create(blogData);
 
+    if (blog.status === 2) {
+      const { sendPushNotification } = await import('@/app/lib/push');
+      await sendPushNotification({
+        title: 'New Blog Published',
+        body: blog.title,
+        data: { blogId: String(blog._id) }
+      });
+    }
+
     return NextResponse.json({ success: true, data: blog }, { status: 201 });
   } catch (error) {
     console.error('Error creating blog:', error);

--- a/app/api/v1/admin/notifications/route.js
+++ b/app/api/v1/admin/notifications/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { sendPushNotification } from '@/app/lib/push';
+import { verifyToken, extractToken } from '@/app/lib/auth';
+
+export async function POST(request) {
+  try {
+    const token = extractToken(request.headers);
+    if (!token) return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    const decoded = verifyToken(token);
+    if (!decoded || decoded.role !== 'admin') {
+      return NextResponse.json({ success: false, error: 'Admin access required' }, { status: 403 });
+    }
+    const body = await request.json();
+    if (!body?.title || !body?.body) {
+      return NextResponse.json({ success: false, error: 'Title and body required' }, { status: 400 });
+    }
+    const res = await sendPushNotification({ title: body.title, body: body.body, data: body.data });
+    if (res.success) return NextResponse.json({ success: true, data: res.data });
+    return NextResponse.json({ success: false, error: res.error }, { status: 500 });
+  } catch (err) {
+    return NextResponse.json({ success: false, error: 'Notification error' }, { status: 500 });
+  }
+}

--- a/app/api/v1/notifications/register/route.js
+++ b/app/api/v1/notifications/register/route.js
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/app/lib/db';
+import NotificationToken from '@/app/models/NotificationToken';
+
+export async function POST(request) {
+  try {
+    await connectDB();
+    const body = await request.json();
+    if (!body?.token) {
+      return NextResponse.json({ success: false, error: 'Token required' }, { status: 400 });
+    }
+    const existing = await NotificationToken.findOne({ token: body.token });
+    if (existing) {
+      return NextResponse.json({ success: true, data: existing });
+    }
+    const token = await NotificationToken.create({ token: body.token, email: body.email, newsletter: body.newsletter });
+    return NextResponse.json({ success: true, data: token }, { status: 201 });
+  } catch (err) {
+    return NextResponse.json({ success: false, error: 'Error registering token' }, { status: 500 });
+  }
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,6 +1,7 @@
 import { Poppins } from "next/font/google";
 import "@/app/globals.css";
 import { Toaster } from "sonner";
+import FCMInit from "@/components/FCMInit";
 
 const poppins = Poppins({
   weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"], // choose weights you want
@@ -145,6 +146,7 @@ export default function RootLayout({ children }) {
         className={`${poppins.variable} antialiased scroll font-poppins group overflow-x-hidden overflow-y-auto has-[.leadPopup:checked]:overflow-hidden`}
       >
         <Toaster position="bottom-center" richColors />
+        <FCMInit />
         {children}
       </body>
     </html>

--- a/app/lib/push.js
+++ b/app/lib/push.js
@@ -1,0 +1,41 @@
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getMessaging } from 'firebase-admin/messaging';
+
+let app;
+export function getFirebaseApp() {
+  if (!app) {
+    const serviceAccount = process.env.FCM_SERVICE_ACCOUNT;
+    if (!serviceAccount) throw new Error('FCM_SERVICE_ACCOUNT not configured');
+    const credentials = JSON.parse(serviceAccount);
+    app = initializeApp({ credential: cert(credentials) });
+  }
+  return app;
+}
+
+export function getFirebaseMessaging() {
+  getFirebaseApp();
+  return getMessaging();
+}
+
+export async function sendPushNotification({ title, body, data }) {
+  const messaging = getFirebaseMessaging();
+  const NotificationToken = (await import('../models/NotificationToken.js')).default;
+  const connectDB = (await import('./db.js')).default;
+  await connectDB();
+  const tokens = await NotificationToken.find().distinct('token');
+  if (!tokens.length) return { success: false, error: 'No tokens registered' };
+  const message = { notification: { title, body }, data: data || {} };
+  const CHUNK_SIZE = 500; // FCM allows max 500 tokens per request
+  const responses = [];
+  try {
+    for (let i = 0; i < tokens.length; i += CHUNK_SIZE) {
+      const chunk = tokens.slice(i, i + CHUNK_SIZE);
+      const res = await messaging.sendEachForMulticast({ tokens: chunk, ...message });
+      responses.push(...res.responses);
+    }
+    return { success: true, data: responses };
+  } catch (err) {
+    console.error('FCM error', err);
+    return { success: false, error: 'Error sending notification' };
+  }
+}

--- a/app/models/NotificationToken.js
+++ b/app/models/NotificationToken.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const notificationTokenSchema = new mongoose.Schema({
+  token: { type: String, required: true, unique: true },
+  email: { type: String },
+  newsletter: { type: Boolean, default: false },
+}, { timestamps: true });
+
+export default mongoose.models.NotificationToken || mongoose.model('NotificationToken', notificationTokenSchema);

--- a/blogScheduler.js
+++ b/blogScheduler.js
@@ -29,6 +29,12 @@ async function publishScheduledBlogs() {
   for (const blog of blogs) {
     blog.status = 2; // Change status to published
     await blog.save();
+    const { sendPushNotification } = await import('./app/lib/push.js');
+    await sendPushNotification({
+      title: 'New Blog Published',
+      body: blog.title,
+      data: { blogId: String(blog._id) }
+    });
     console.log(`Published blog: ${blog.title} (${blog._id})`);
   }
 }

--- a/components/FCMInit.jsx
+++ b/components/FCMInit.jsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect } from 'react';
+import { initializeApp } from 'firebase/app';
+import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { toast } from 'sonner';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
+};
+
+export default function FCMInit() {
+  useEffect(() => {
+    if (typeof window === 'undefined' || !firebaseConfig.apiKey) return;
+    const app = initializeApp(firebaseConfig);
+    const messaging = getMessaging(app);
+    Notification.requestPermission().then(async perm => {
+      if (perm === 'granted') {
+        try {
+          const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
+          const token = await getToken(messaging, { vapidKey: process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY, serviceWorkerRegistration: registration });
+          if (token) {
+            await fetch('/api/v1/notifications/register', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token })
+            });
+          }
+        } catch (err) {
+          console.error('FCM token error', err);
+        }
+      }
+    });
+    onMessage(messaging, payload => {
+      toast.info(payload.notification?.title || 'New Notification');
+    });
+  }, []);
+  return null;
+}

--- a/components/FCMInit.jsx
+++ b/components/FCMInit.jsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect } from 'react';
-import { initializeApp } from 'firebase/app';
-import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { initializeApp, getApps } from 'firebase/app';
+import { getMessaging, getToken, onMessage, isSupported } from 'firebase/messaging';
 import { toast } from 'sonner';
 
 const firebaseConfig = {
@@ -16,11 +16,13 @@ const firebaseConfig = {
 export default function FCMInit() {
   useEffect(() => {
     if (typeof window === 'undefined' || !firebaseConfig.apiKey) return;
-    const app = initializeApp(firebaseConfig);
+    const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
     const messaging = getMessaging(app);
 
     const init = async () => {
       try {
+        const supported = await isSupported();
+        if (!supported) return;
         const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
         const permission = await Notification.requestPermission();
         if (permission !== 'granted') return;

--- a/middleware.js
+++ b/middleware.js
@@ -32,7 +32,7 @@ export async function middleware(request) {
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  response.headers.set('Content-Security-Policy', "default-src 'self' https://cdn.tiny.cloud; img-src 'self' https://cdn.tiny.cloud blob: data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tiny.cloud; style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud; font-src 'self' 'unsafe-inline' data: https://cdn.tiny.cloud;");
+  response.headers.set('Content-Security-Policy', "default-src 'self' https://cdn.tiny.cloud; connect-src 'self' https://fcmregistrations.googleapis.com https://firebaseinstallations.googleapis.com https://fcm.googleapis.com https://oauth2.googleapis.com https://www.googleapis.com; img-src 'self' https://cdn.tiny.cloud blob: data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tiny.cloud https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud; font-src 'self' 'unsafe-inline' data: https://cdn.tiny.cloud;");
   response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
   const { pathname, search, origin } = request.nextUrl;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "dev:https": "node server.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.837.0",
@@ -73,6 +74,7 @@
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "autoprefixer": "^10.4.21",
+    "devcert": "^1.2.2",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "eslint-config-prettier": "^10.1.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@tinymce/tinymce-react": "^6.2.1",
     "@vercel/speed-insights": "^1.2.0",
     "aws-sdk": "^2.1692.0",
+    "firebase": "^10.8.0",
+    "firebase-admin": "^12.0.0",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,18 +1,19 @@
-importScripts('https://www.gstatic.com/firebasejs/10.11.0/firebase-app-compat.js');
-importScripts('https://www.gstatic.com/firebasejs/10.11.0/firebase-messaging-compat.js');
+import { initializeApp } from 'firebase/app';
+import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw';
 
-firebase.initializeApp({
+const firebaseConfig = {
   apiKey: 'AIzaSyC-Kyf7bL6e9sHsrxrGeYNa377e2HMNgNQ',
   authDomain: 'imgglobaljaipur.firebaseapp.com',
   projectId: 'imgglobaljaipur',
   messagingSenderId: '25119988071',
-  appId: '1:25119988071:web:45d01eacbdf48a81f5b7c2',
-});
+  appId: '1:25119988071:web:45d01eacbdf48a81f5b7c2'
+};
 
-const messaging = firebase.messaging();
+const app = initializeApp(firebaseConfig);
+const messaging = getMessaging(app);
 
-messaging.onBackgroundMessage(function(payload) {
+onBackgroundMessage(messaging, payload => {
   self.registration.showNotification(payload.notification.title, {
-    body: payload.notification.body,
+    body: payload.notification.body
   });
 });

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,18 @@
+importScripts('https://www.gstatic.com/firebasejs/10.11.0/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/10.11.0/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: 'AIzaSyC-Kyf7bL6e9sHsrxrGeYNa377e2HMNgNQ',
+  authDomain: 'imgglobaljaipur.firebaseapp.com',
+  projectId: 'imgglobaljaipur',
+  messagingSenderId: '25119988071',
+  appId: '1:25119988071:web:45d01eacbdf48a81f5b7c2',
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage(function(payload) {
+  self.registration.showNotification(payload.notification.title, {
+    body: payload.notification.body,
+  });
+});

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,19 +1,18 @@
-import { initializeApp } from 'firebase/app';
-import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw';
+importScripts('https://www.gstatic.com/firebasejs/10.8.0/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/10.8.0/firebase-messaging-compat.js');
 
-const firebaseConfig = {
+firebase.initializeApp({
   apiKey: 'AIzaSyC-Kyf7bL6e9sHsrxrGeYNa377e2HMNgNQ',
   authDomain: 'imgglobaljaipur.firebaseapp.com',
   projectId: 'imgglobaljaipur',
   messagingSenderId: '25119988071',
   appId: '1:25119988071:web:45d01eacbdf48a81f5b7c2'
-};
+});
 
-const app = initializeApp(firebaseConfig);
-const messaging = getMessaging(app);
+const messaging = firebase.messaging();
 
-onBackgroundMessage(messaging, payload => {
-  self.registration.showNotification(payload.notification.title, {
-    body: payload.notification.body
+messaging.onBackgroundMessage(payload => {
+  self.registration.showNotification(payload.notification?.title ?? 'New Notification', {
+    body: payload.notification?.body ?? ''
   });
 });

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,18 +1,9 @@
-importScripts('https://www.gstatic.com/firebasejs/10.8.0/firebase-app-compat.js');
-importScripts('https://www.gstatic.com/firebasejs/10.8.0/firebase-messaging-compat.js');
-
-firebase.initializeApp({
-  apiKey: 'AIzaSyC-Kyf7bL6e9sHsrxrGeYNa377e2HMNgNQ',
-  authDomain: 'imgglobaljaipur.firebaseapp.com',
-  projectId: 'imgglobaljaipur',
-  messagingSenderId: '25119988071',
-  appId: '1:25119988071:web:45d01eacbdf48a81f5b7c2'
-});
-
-const messaging = firebase.messaging();
-
-messaging.onBackgroundMessage(payload => {
-  self.registration.showNotification(payload.notification?.title ?? 'New Notification', {
-    body: payload.notification?.body ?? ''
-  });
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.notification?.title || 'New Notification';
+  const options = {
+    body: data.notification?.body || '',
+    data: data.data || {}
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
 });

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,20 @@
+import { createServer } from 'https';
+import { parse } from 'url';
+import next from 'next';
+import devcert from 'devcert';
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+const port = parseInt(process.env.PORT || '3000', 10);
+
+(async () => {
+  const { key, cert } = await devcert.certificateFor('localhost');
+  await app.prepare();
+  createServer({ key, cert }, (req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(port, () => {
+    console.log(`> Ready on https://localhost:${port}`);
+  });
+})();


### PR DESCRIPTION
## Summary
- implement Firebase Cloud Messaging support
- register notification tokens from the client
- send push notifications when blogs are published
- allow admins to manually trigger blog notifications
- run notifications from the blog scheduler
- inject FCM initialization in layouts
- avoid FCM errors by chunking push tokens when sending

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860c31d90008328adcb866e3ffe37e0