### PR TITLE
Fix hydration mismatch for BlogTable

### DIFF
--- a/app/admin/blogs/page.jsx
+++ b/app/admin/blogs/page.jsx
@@ -1,6 +1,11 @@
+import { cookies } from "next/headers";
 import { BlogTable } from "@/components/blogTable";
+import { hasServerPermission } from "@/helpers/permissions";
 
 export default async function Page() {
+  const store = await cookies();
+  const canAdd = hasServerPermission(store, 'blogs', 'write');
+
   const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs`, { cache: 'no-store' });
   const json = await res.json();
   const blogs = Array.isArray(json?.data) ? json.data : [];
@@ -24,7 +29,7 @@ export default async function Page() {
   return (
     <>
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <BlogTable data={data} />
+        <BlogTable data={data} canAdd={canAdd} />
       </div>
     </>
   );

--- a/components/blogTable.jsx
+++ b/components/blogTable.jsx
@@ -397,7 +397,7 @@ export const columns = [
   },
 ];
 
-export function BlogTable({ data }) {
+export function BlogTable({ data, canAdd = false }) {
   const [sorting, setSorting] = React.useState([]);
   const [columnFilters, setColumnFilters] = React.useState([]);
   const [columnVisibility, setColumnVisibility] = React.useState({});
@@ -455,7 +455,7 @@ export function BlogTable({ data }) {
               ))}
           </DropdownMenuContent>
         </DropdownMenu>
-        {hasClientPermission('blogs', 'write') && (
+        {canAdd && (
           <Button asChild>
             <Link href="/admin/blogs/add"><Plus /> Add Blog</Link>
           </Button>


### PR DESCRIPTION
## Summary
- check blog permissions on the server
- pass `canAdd` flag to `BlogTable`
- rely on the flag instead of a client-side check to render the Add Blog button

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862726e4b58832892b2f4820d6c8ac1