### PR TITLE
Switch cache JSON storage to Redis

### DIFF
--- a/app/lib/adminsFile.js
+++ b/app/lib/adminsFile.js
@@ -1,55 +1,49 @@
-import { promises as fs } from 'fs';
-import path from 'path';
+import { getRedis } from './redis';
 import connectDB from '@/app/lib/db';
 import Admin from '@/app/models/Admin';
 import '@/app/models/Department';
 
-export const DATA_FILE = path.join(process.cwd(), 'data', 'admins.json');
+const KEY = 'admins';
 
 export async function ensureAdminsFile() {
-  try {
-    await fs.access(DATA_FILE);
-    return false;
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      await fs.mkdir(path.dirname(DATA_FILE), { recursive: true });
-      await fs.writeFile(DATA_FILE, '[]', 'utf8');
-      return true;
-    }
-    throw err;
-  }
+  const redis = getRedis();
+  const exists = await redis.exists(KEY);
+  return !exists;
 }
 
 export async function readAdmins() {
-  await ensureAdminsFile();
-  try {
-    const data = await fs.readFile(DATA_FILE, 'utf8');
-    return JSON.parse(data);
-  } catch (err) {
-    if (err instanceof SyntaxError) {
+  const redis = getRedis();
+  const data = await redis.get(KEY);
+  if (data) {
+    try {
+      return JSON.parse(data);
+    } catch {
       const { admins } = await syncAdminsFromDB();
       return admins;
     }
-    throw err;
   }
+  const { admins } = await syncAdminsFromDB();
+  return admins;
 }
 
 export async function readAdminsWithNotice() {
-  try {
-    const data = await fs.readFile(DATA_FILE, 'utf8');
-    return { admins: JSON.parse(data), wasCreated: false };
-  } catch (err) {
-    if (err.code === 'ENOENT' || err instanceof SyntaxError) {
+  const redis = getRedis();
+  const data = await redis.get(KEY);
+  if (data) {
+    try {
+      return { admins: JSON.parse(data), wasCreated: false };
+    } catch {
       const { admins } = await syncAdminsFromDB();
       return { admins, wasCreated: true };
     }
-    throw err;
   }
+  const { admins } = await syncAdminsFromDB();
+  return { admins, wasCreated: true };
 }
 
 export async function writeAdmins(admins) {
-  await fs.mkdir(path.dirname(DATA_FILE), { recursive: true });
-  await fs.writeFile(DATA_FILE, JSON.stringify(admins, null, 2), 'utf8');
+  const redis = getRedis();
+  await redis.set(KEY, JSON.stringify(admins));
 }
 
 export async function syncAdminsFromDB() {
@@ -65,7 +59,8 @@ export async function syncAdminsFromDB() {
     createdAt: doc.createdAt.toISOString(),
     updatedAt: doc.updatedAt.toISOString(),
   }));
-  const wasCreated = await ensureAdminsFile();
+  const redis = getRedis();
+  const existed = await redis.exists(KEY);
   await writeAdmins(admins);
-  return { admins, wasCreated };
+  return { admins, wasCreated: !existed };
 }

--- a/app/lib/redis.js
+++ b/app/lib/redis.js
@@ -1,0 +1,18 @@
+import { createClient } from 'redis';
+
+const REDIS_URL = process.env.REDIS_URL;
+
+if (!REDIS_URL) {
+  throw new Error('REDIS_URL env variable is not defined');
+}
+
+let client;
+
+export function getRedis() {
+  if (!client) {
+    client = createClient({ url: REDIS_URL });
+    client.on('error', (err) => console.error('Redis Client Error', err));
+    client.connect().catch((err) => console.error('Redis connect error', err));
+  }
+  return client;
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "tailwind-merge": "^3.3.0",
     "tinymce": "^7.9.1",
     "zod": "^3.25.64",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "redis": "^5.5.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- move caching logic from filesystem JSON files to Redis
- include `redis` dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627aa587bc8328a045e9ac720a93d6