### PR TITLE
Disable admin redirection check

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -57,12 +57,14 @@ export async function middleware(request) {
     return response;
   }
 
-  const redirects = await getRedirections(origin);
-  const pathWithQuery = pathname + search;
-  const match = redirects.find(r => r.from === pathWithQuery || r.from === pathname);
-  if (match) {
-    const url = match.to.startsWith('http') ? match.to : `${origin}${match.to}`;
-    return NextResponse.redirect(url, match.methodCode);
+  if (!pathname.startsWith('/admin')) {
+    const redirects = await getRedirections(origin);
+    const pathWithQuery = pathname + search;
+    const match = redirects.find(r => r.from === pathWithQuery || r.from === pathname);
+    if (match) {
+      const url = match.to.startsWith('http') ? match.to : `${origin}${match.to}`;
+      return NextResponse.redirect(url, match.methodCode);
+    }
   }
 
     const token = request.cookies.get('token')?.value;


### PR DESCRIPTION
## Summary
- skip checking frontend redirection rules on admin pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863a0b09aa08328838252f22ae50522