### PR TITLE
Improve blog search performance

### DIFF
--- a/app/actions/blogs.js
+++ b/app/actions/blogs.js
@@ -1,0 +1,18 @@
+'use server';
+
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+
+export async function getBlogs() {
+  try {
+    await connectDB();
+    const blogs = await Blog.find({}, 'title banner status created_date slug').lean();
+    return blogs.map(b => ({
+      ...b,
+      _id: b._id.toString(),
+    }));
+  } catch (err) {
+    console.error('Error fetching blogs:', err);
+    return [];
+  }
+}

--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -51,7 +51,16 @@ import apiFetch from "@/helpers/apiFetch";
 import ImageCropperInput from "@/components/image-cropper-input";
 import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import { useParams, useRouter } from "next/navigation";
-import TinyMCEEditor from "@/components/TinyMCEEditor";
+import dynamic from "next/dynamic";
+
+const TinyMCEEditor = dynamic(() => import("@/components/TinyMCEEditor"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-96 flex items-center justify-center text-sm text-muted-foreground">
+      Loading editor...
+    </div>
+  ),
+});
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 const faqEditorInit = {

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -53,7 +53,16 @@ import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import { useSearchParams, useRouter } from "next/navigation";
 import Loader from "@/components/ui/loader";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import TinyMCEEditor from "@/components/TinyMCEEditor";
+import dynamic from "next/dynamic";
+
+const TinyMCEEditor = dynamic(() => import("@/components/TinyMCEEditor"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-96 flex items-center justify-center text-sm text-muted-foreground">
+      Loading editor...
+    </div>
+  ),
+});
 
 const faqEditorInit = {
   menubar: false,

--- a/app/admin/blogs/page.jsx
+++ b/app/admin/blogs/page.jsx
@@ -1,14 +1,13 @@
 import { cookies } from "next/headers";
 import { BlogTable } from "@/components/blogTable";
 import { hasServerPermission } from "@/helpers/permissions";
+import { getBlogs } from "@/app/actions/blogs";
 
 export default async function Page() {
   const store = await cookies();
   const canAdd = hasServerPermission(store, 'blogs', 'write');
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs`, { cache: 'no-store' });
-  const json = await res.json();
-  const blogs = Array.isArray(json?.data) ? json.data : [];
+  const blogs = await getBlogs();
   const statusMap = { 1: 'draft', 2: 'published', 3: 'archived', 4: 'scheduled' };
   const data = blogs.map(blog => {
     const obj = {

--- a/app/api/v1/admin/blogs/authors/route.js
+++ b/app/api/v1/admin/blogs/authors/route.js
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server';
 import connectDB from '@/app/lib/db';
 import Author, { AUTHOR_STATUS } from '@/app/models/Author';
 import Blog from '@/app/models/Blog';
-import Fuse from 'fuse.js';// We'll need this for blog count
 import { verifyToken, extractToken } from '@/app/lib/auth';
 import { uploadAuthorImage } from '@/app/middleware/imageUpload';
 
@@ -47,37 +46,26 @@ export async function GET(request) {
       baseQuery.status = numericStatus;
     }
 
-    // Get all authors first for Fuse.js search
-    let allAuthors = await Author.find(baseQuery, null, { showDeleted })
-      .select('-__v')
-      .lean(); // Using lean for better performance
-
-    // Apply Fuse.js search if search parameter exists
+    // Apply search using regex on author_name, description, and slug
     if (search) {
-      const fuseOptions = {
-        keys: ['author_name', 'description', 'slug'],
-        threshold: 0.3, // Adjust this value for search sensitivity (0.0 is exact match)
-        includeScore: true
-      };
-      const fuse = new Fuse(allAuthors, fuseOptions);
-      const searchResults = fuse.search(search);
-      allAuthors = searchResults.map(result => result.item);
+      const regex = new RegExp(search, 'i');
+      baseQuery.$or = [
+        { author_name: regex },
+        { description: regex },
+        { slug: regex }
+      ];
     }
 
-    // Get total count after search
-    const total = allAuthors.length;
+    // Get total count directly from the database
+    const total = await Author.countDocuments(baseQuery).setOptions({ showDeleted });
 
-    // Apply sorting
-    if (sortBy) {
-      allAuthors.sort((a, b) => {
-        const aValue = a[sortBy];
-        const bValue = b[sortBy];
-        return sortOrder * (aValue > bValue ? 1 : -1);
-      });
-    }
-
-    // Apply pagination manually after search
-    const authors = allAuthors.slice(skip, skip + limit);
+    // Query authors with sorting and pagination handled by MongoDB
+    const authors = await Author.find(baseQuery, null, { showDeleted })
+      .select('-__v')
+      .sort({ [sortBy]: sortOrder })
+      .skip(skip)
+      .limit(limit)
+      .lean();
 
     // Update blog counts for all authors
     const authorsWithCounts = await Promise.all(authors.map(async (author) => {


### PR DESCRIPTION
## Summary
- replace Fuse.js search with MongoDB query
- filter by `status` and support regex search on title, short description, and slug
- apply sort, skip and limit directly in the query
- use `countDocuments` for pagination totals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863c9df8a008328a829c63fe7818473