### PR TITLE
Use dynamic import for TinyMCEEditor

### DIFF
--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -51,7 +51,16 @@ import apiFetch from "@/helpers/apiFetch";
 import ImageCropperInput from "@/components/image-cropper-input";
 import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import { useParams, useRouter } from "next/navigation";
-import TinyMCEEditor from "@/components/TinyMCEEditor";
+import dynamic from "next/dynamic";
+
+const TinyMCEEditor = dynamic(() => import("@/components/TinyMCEEditor"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-96 flex items-center justify-center text-sm text-muted-foreground">
+      Loading editor...
+    </div>
+  ),
+});
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 const faqEditorInit = {

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -53,7 +53,16 @@ import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import { useSearchParams, useRouter } from "next/navigation";
 import Loader from "@/components/ui/loader";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import TinyMCEEditor from "@/components/TinyMCEEditor";
+import dynamic from "next/dynamic";
+
+const TinyMCEEditor = dynamic(() => import("@/components/TinyMCEEditor"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-96 flex items-center justify-center text-sm text-muted-foreground">
+      Loading editor...
+    </div>
+  ),
+});
 
 const faqEditorInit = {
   menubar: false,


### PR DESCRIPTION
## Summary
- load TinyMCEEditor dynamically on blog pages
- show a small placeholder while the editor loads

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot read properties of undefined (reading 'env'))*

------
https://chatgpt.com/codex/tasks/task_e_6863c9ee39b88328bb8c7a1acc35469c