### PR TITLE
Refactor blogs list fetch to use server action

### DIFF
--- a/app/actions/blogs.js
+++ b/app/actions/blogs.js
@@ -1,0 +1,18 @@
+'use server';
+
+import connectDB from '@/app/lib/db';
+import Blog from '@/app/models/Blog';
+
+export async function getBlogs() {
+  try {
+    await connectDB();
+    const blogs = await Blog.find({}, 'title banner status created_date slug').lean();
+    return blogs.map(b => ({
+      ...b,
+      _id: b._id.toString(),
+    }));
+  } catch (err) {
+    console.error('Error fetching blogs:', err);
+    return [];
+  }
+}

--- a/app/admin/blogs/page.jsx
+++ b/app/admin/blogs/page.jsx
@@ -1,14 +1,13 @@
 import { cookies } from "next/headers";
 import { BlogTable } from "@/components/blogTable";
 import { hasServerPermission } from "@/helpers/permissions";
+import { getBlogs } from "@/app/actions/blogs";
 
 export default async function Page() {
   const store = await cookies();
   const canAdd = hasServerPermission(store, 'blogs', 'write');
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs`, { cache: 'no-store' });
-  const json = await res.json();
-  const blogs = Array.isArray(json?.data) ? json.data : [];
+  const blogs = await getBlogs();
   const statusMap = { 1: 'draft', 2: 'published', 3: 'archived', 4: 'scheduled' };
   const data = blogs.map(blog => {
     const obj = {


### PR DESCRIPTION
## Summary
- add server action `getBlogs` for fetching blogs
- refactor admin blogs page to call the server action directly

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863c9f1da248328bc8112fa404992ee