### PR TITLE
Fix admin profile access

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -4,6 +4,7 @@ import { getRedirections } from './app/lib/redirections';
 
 function getModuleAction(pathname) {
   if (!pathname.startsWith('/admin')) return null;
+  if (pathname.startsWith('/admin/profile')) return null;
   const parts = pathname.split('/').filter(Boolean);
   if (parts.length < 2) return null;
   let mod = parts[1];


### PR DESCRIPTION
## Summary
- allow admins to view and edit their own profile without explicit permissions

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863e202f570832883973ed4299844b3