### PR TITLE
Fix logout issue on profile edit

### DIFF
--- a/app/actions/admin.js
+++ b/app/actions/admin.js
@@ -270,9 +270,11 @@ export async function updateAdmin(id, formData) {
       if (!department) {
         return { success: false, error: 'Department not found' };
       }
-      admin.department = department._id;
-      admin.permissions = department.permissions;
-      admin.permissionsUpdatedAt = new Date();
+      if (!admin.department || admin.department.toString() !== dept) {
+        admin.department = department._id;
+        admin.permissions = department.permissions;
+        admin.permissionsUpdatedAt = new Date();
+      }
     }
 
     await admin.save();

--- a/app/admin/admins/[id]/edit/EditAdminForm.jsx
+++ b/app/admin/admins/[id]/edit/EditAdminForm.jsx
@@ -78,6 +78,7 @@ export default function EditAdminForm({
     try {
       const fd = new FormData();
       Object.entries(values).forEach(([k, v]) => {
+        if (hideDepartment && k === 'department') return;
         if (k === 'profileImage') {
           if (v && v[0]) fd.append('profileImage', v[0]);
         } else if (v) {

--- a/app/admin/profile/edit/page.jsx
+++ b/app/admin/profile/edit/page.jsx
@@ -16,7 +16,7 @@ export default async function Page() {
     <div className="w-full p-4">
       <EditAdminForm
         admin={admin}
-        hideDepartment={admin.role === 'superadmin'}
+        hideDepartment={admin.role !== 'superadmin'}
         redirectTo="/admin/profile"
       />
     </div>


### PR DESCRIPTION
## Summary
- hide department field when an admin edits their own profile
- skip sending department when hidden
- avoid updating `permissionsUpdatedAt` unless department actually changes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6863e7a6ed7c8328976af040d968ea45