### PR TITLE
Fix superadmin profile edit

### DIFF
--- a/app/admin/profile/edit/page.jsx
+++ b/app/admin/profile/edit/page.jsx
@@ -16,7 +16,7 @@ export default async function Page() {
     <div className="w-full p-4">
       <EditAdminForm
         admin={admin}
-        hideDepartment={admin.role !== 'superadmin'}
+        hideDepartment={admin.role === 'superadmin'}
         redirectTo="/admin/profile"
       />
     </div>


### PR DESCRIPTION
## Summary
- hide department field on profile edit when admin is superadmin

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686417bec84c8328b316193319691e7f