### PR TITLE
Add caching for admin pages with Zustand

### DIFF
--- a/app/(auth)/reset-password/page.jsx
+++ b/app/(auth)/reset-password/page.jsx
@@ -3,6 +3,7 @@ import ResetForm from "./resetForm";
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Suspense } from "react";
+import { FormSkeleton } from "@/components/skeleton/form-skeleton";
 
 const title = 'Reset Password';
 
@@ -37,7 +38,7 @@ const ResetPasswordPage = () => {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <Suspense fallback={<p>Loading...</p>}>
+        <Suspense fallback={<FormSkeleton rows={3} />}>
           <ResetForm />
         </Suspense>
         <div className="mt-4 text-center text-sm">

--- a/app/admin/admins/AdminsPageClient.jsx
+++ b/app/admin/admins/AdminsPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { AdminTable } from '@/components/adminTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function AdminsPageClient({ token, canAdd }) {
   const { data: admins, loading } = useCachedApi('admins', async () => {
@@ -12,7 +13,7 @@ export default function AdminsPageClient({ token, canAdd }) {
   });
 
   if (loading || !admins) {
-    return <div className="p-4">Loading...</div>;
+    return <TableSkeleton />;
   }
 
   const rows = admins

--- a/app/admin/admins/AdminsPageClient.jsx
+++ b/app/admin/admins/AdminsPageClient.jsx
@@ -1,0 +1,33 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { AdminTable } from '@/components/adminTable';
+
+export default function AdminsPageClient({ token, canAdd }) {
+  const { data: admins, loading } = useCachedApi('admins', async () => {
+    const res = await fetch('/api/v1/admin/admins', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const json = await res.json();
+    return Array.isArray(json?.data) ? json.data : [];
+  });
+
+  if (loading || !admins) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  const rows = admins
+    .filter(a => a.role !== 'superadmin')
+    .map(a => ({
+      id: a.id,
+      email: a.email,
+      role: a.role,
+      department: a.department || '',
+      createdAt: a.createdAt,
+    }));
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <AdminTable data={rows} canAdd={canAdd} />
+    </div>
+  );
+}

--- a/app/admin/admins/page.jsx
+++ b/app/admin/admins/page.jsx
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { AdminTable } from "@/components/adminTable";
 import { hasServerPermission } from "@/helpers/permissions";
+import AdminsPageClient from "./AdminsPageClient";
 
 export default async function Page() {
   const store = await cookies();
@@ -10,28 +10,7 @@ export default async function Page() {
     redirect("/admin");
   }
   const canAdd = hasServerPermission(store, 'admins', 'write');
-
-  const base = process.env.NEXT_PUBLIC_BASE_URL || '';
   const token = store.get("token")?.value || '';
-  const res = await fetch(`${base}/api/v1/admin/admins`, {
-    cache: 'no-store',
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await res.json();
-  const admins = Array.isArray(json?.data) ? json.data : [];
-  const data = admins
-    .filter((a) => a.role !== 'superadmin')
-    .map((a) => ({
-      id: a.id,
-      email: a.email,
-      role: a.role,
-      department: a.department || '',
-      createdAt: a.createdAt,
-    }));
 
-  return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      <AdminTable data={data} canAdd={canAdd} />
-    </div>
-  );
+  return <AdminsPageClient token={token} canAdd={canAdd} />;
 }

--- a/app/admin/blogs/BlogsPageClient.jsx
+++ b/app/admin/blogs/BlogsPageClient.jsx
@@ -1,0 +1,35 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { BlogTable } from '@/components/blogTable';
+
+export default function BlogsPageClient({ canAdd }) {
+  const { data, loading } = useCachedApi('blogs', async () => {
+    const res = await fetch('/api/v1/admin/blogs');
+    const json = await res.json();
+    const blogs = Array.isArray(json?.data) ? json.data : [];
+    const statusMap = { 1: 'draft', 2: 'published', 3: 'archived', 4: 'scheduled' };
+    return blogs.map(blog => {
+      const obj = {
+        id: blog.id,
+        title: blog.title,
+        status: statusMap[blog.status] || 'draft',
+        created_date: blog.created_date,
+        slug: blog.slug,
+      };
+      if (blog.banner) {
+        obj.banner = blog.banner?.startsWith('http')
+          ? blog.banner
+          : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/blogs/${blog.banner}`;
+      }
+      return obj;
+    });
+  });
+
+  if (loading || !data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <BlogTable data={data} canAdd={canAdd} />
+    </div>
+  );
+}

--- a/app/admin/blogs/BlogsPageClient.jsx
+++ b/app/admin/blogs/BlogsPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { BlogTable } from '@/components/blogTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function BlogsPageClient({ canAdd }) {
   const { data, loading } = useCachedApi('blogs', async () => {
@@ -25,7 +26,7 @@ export default function BlogsPageClient({ canAdd }) {
     });
   });
 
-  if (loading || !data) return <div className="p-4">Loading...</div>;
+  if (loading || !data) return <TableSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -52,10 +52,11 @@ import ImageCropperInput from "@/components/image-cropper-input";
 import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import { useParams, useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
+import { EditorSkeleton } from "@/components/skeleton/editor-skeleton";
 
 const TinyMCEEditor = dynamic(() => import("@/components/TinyMCEEditor"), {
   ssr: false,
-  loading: () => <p>Loading editor...</p>,
+  loading: () => <EditorSkeleton />,
 });
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -54,10 +54,12 @@ import { useSearchParams, useRouter } from "next/navigation";
 import Loader from "@/components/ui/loader";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import dynamic from "next/dynamic";
+import { EditorSkeleton } from "@/components/skeleton/editor-skeleton";
+import { FormSkeleton } from "@/components/skeleton/form-skeleton";
 
 const TinyMCEEditor = dynamic(() => import("@/components/TinyMCEEditor"), {
   ssr: false,
-  loading: () => <p>Loading editor...</p>,
+  loading: () => <EditorSkeleton />,
 });
 
 const faqEditorInit = {
@@ -1149,7 +1151,7 @@ function BlogAdd() {
 
 export default function Page() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<FormSkeleton rows={8} />}>
       <BlogAdd />
     </Suspense>
   );

--- a/app/admin/blogs/authors/AuthorsPageClient.jsx
+++ b/app/admin/blogs/authors/AuthorsPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { AuthorTable } from '@/components/authorTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function AuthorsPageClient({ canAdd, canEdit }) {
   const { data, loading } = useCachedApi('authors', async () => {
@@ -23,7 +24,7 @@ export default function AuthorsPageClient({ canAdd, canEdit }) {
     }));
   });
 
-  if (loading || !data) return <div className="p-4">Loading...</div>;
+  if (loading || !data) return <TableSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/blogs/authors/AuthorsPageClient.jsx
+++ b/app/admin/blogs/authors/AuthorsPageClient.jsx
@@ -1,0 +1,33 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { AuthorTable } from '@/components/authorTable';
+
+export default function AuthorsPageClient({ canAdd, canEdit }) {
+  const { data, loading } = useCachedApi('authors', async () => {
+    const res = await fetch('/api/v1/admin/blogs/authors');
+    const json = await res.json();
+    const authors = Array.isArray(json?.data) ? json.data : [];
+    const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
+    return authors.map(author => ({
+      id: author._id,
+      author_name: author.author_name,
+      description: author.description,
+      linkedin_link: author.linkedin_link,
+      facebook_link: author.facebook_link,
+      twitter_link: author.twitter_link,
+      status: statusMap[author.status] || 'inactive',
+      image: author.image?.startsWith('http') ? author.image : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/authors/${author.image}`,
+      created_date: author.created_date,
+      modified_date: author.modified_date,
+      blog_count: author.blog_count || 0,
+    }));
+  });
+
+  if (loading || !data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <AuthorTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/page.jsx
+++ b/app/admin/blogs/authors/page.jsx
@@ -1,38 +1,10 @@
-import { AuthorTable } from "@/components/authorTable";
 import { cookies } from "next/headers";
 import { hasServerPermission } from "@/helpers/permissions";
+import AuthorsPageClient from "./AuthorsPageClient";
 
 export default async function Page() {
   const store = await cookies();
   const canAdd = hasServerPermission(store, 'authors', 'write');
   const canEdit = hasServerPermission(store, 'authors', 'edit');
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/authors`, { cache: 'no-store' });
-  const json = await res.json();
-  const authors = Array.isArray(json?.data) ? json.data : [];
-  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
-  const data = authors.map(author => ({
-    id: author._id,
-    author_name: author.author_name,
-    description: author.description,
-    linkedin_link: author.linkedin_link,
-    facebook_link: author.facebook_link,
-    twitter_link: author.twitter_link,
-    status: statusMap[author.status] || 'inactive',
-    image: author.image?.startsWith('http') ? author.image : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/authors/${author.image}`,
-    created_date: author.created_date,
-    modified_date: author.modified_date,
-    blog_count: author.blog_count || 0,
-  }));
-
-  return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        {/* <div className="space-y-1">
-          <h2 className="text-3xl font-bold tracking-tight">Authors</h2>
-          <p className="text-muted-foreground">Authors are the people who have contributed to the blogs.</p>
-        </div> */}
-        <AuthorTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
-  );
+  return <AuthorsPageClient canAdd={canAdd} canEdit={canEdit} />;
 }

--- a/app/admin/blogs/categories/CategoriesPageClient.jsx
+++ b/app/admin/blogs/categories/CategoriesPageClient.jsx
@@ -1,0 +1,29 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { CategoryTable } from '@/components/categoryTable';
+
+export default function CategoriesPageClient({ canAdd, canEdit }) {
+  const { data, loading } = useCachedApi('categories', async () => {
+    const res = await fetch('/api/v1/admin/blogs/categories');
+    const json = await res.json();
+    const categories = Array.isArray(json?.data) ? json.data : [];
+    const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
+    return categories.map(cat => ({
+      id: cat._id,
+      category_name: cat.category_name,
+      description: cat.description,
+      status: statusMap[cat.status] || 'inactive',
+      created_date: cat.created_date,
+      modified_date: cat.modified_date,
+      blog_count: cat.blog_count,
+    }));
+  });
+
+  if (loading || !data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/CategoriesPageClient.jsx
+++ b/app/admin/blogs/categories/CategoriesPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { CategoryTable } from '@/components/categoryTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function CategoriesPageClient({ canAdd, canEdit }) {
   const { data, loading } = useCachedApi('categories', async () => {
@@ -19,7 +20,7 @@ export default function CategoriesPageClient({ canAdd, canEdit }) {
     }));
   });
 
-  if (loading || !data) return <div className="p-4">Loading...</div>;
+  if (loading || !data) return <TableSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/blogs/categories/page.jsx
+++ b/app/admin/blogs/categories/page.jsx
@@ -1,30 +1,10 @@
-import { CategoryTable } from "@/components/categoryTable";
 import { cookies } from "next/headers";
 import { hasServerPermission } from "@/helpers/permissions";
+import CategoriesPageClient from "./CategoriesPageClient";
 
 export default async function Page() {
   const store = await cookies();
   const canAdd = hasServerPermission(store, 'categories', 'write');
   const canEdit = hasServerPermission(store, 'categories', 'edit');
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories`, { cache: 'no-store' });
-  const json = await res.json();
-  const categories = Array.isArray(json?.data) ? json.data : [];
-  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
-  const data = categories.map(cat => ({
-    id: cat._id,
-    category_name: cat.category_name,
-    description: cat.description,
-    status: statusMap[cat.status] || 'inactive',
-    created_date: cat.created_date,
-    modified_date: cat.modified_date,
-    blog_count: cat.blog_count,
-  }));
-
-  return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
-  );
+  return <CategoriesPageClient canAdd={canAdd} canEdit={canEdit} />;
 }

--- a/app/admin/blogs/images/ImagesPageClient.jsx
+++ b/app/admin/blogs/images/ImagesPageClient.jsx
@@ -1,0 +1,28 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { ImageTable } from '@/components/ImageTable';
+
+export default function ImagesPageClient({ canAdd, canEdit }) {
+  const { data, loading } = useCachedApi('images', async () => {
+    const res = await fetch('/api/v1/admin/images');
+    const json = await res.json();
+    const images = Array.isArray(json?.data) ? json.data : [];
+    return images.map(img => ({
+      id: img._id,
+      storedName: img.storedName,
+      uploadedBy: img.uploadedBy,
+      url: img.storedName?.startsWith('http')
+        ? img.storedName
+        : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${img.storedName}?t=${Date.now()}`,
+      createdAt: img.createdAt,
+    }));
+  });
+
+  if (loading || !data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <ImageTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
+  );
+}

--- a/app/admin/blogs/images/ImagesPageClient.jsx
+++ b/app/admin/blogs/images/ImagesPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { ImageTable } from '@/components/ImageTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function ImagesPageClient({ canAdd, canEdit }) {
   const { data, loading } = useCachedApi('images', async () => {
@@ -18,7 +19,7 @@ export default function ImagesPageClient({ canAdd, canEdit }) {
     }));
   });
 
-  if (loading || !data) return <div className="p-4">Loading...</div>;
+  if (loading || !data) return <TableSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/blogs/images/page.jsx
+++ b/app/admin/blogs/images/page.jsx
@@ -1,32 +1,11 @@
-import { ImageTable } from "@/components/ImageTable";
 import { cookies } from "next/headers";
 import { hasServerPermission } from "@/helpers/permissions";
+import ImagesPageClient from "./ImagesPageClient";
 
 export default async function Page() {
   const store = await cookies();
   const canAdd = hasServerPermission(store, 'images', 'write');
   const canEdit = hasServerPermission(store, 'images', 'edit');
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/images`, { cache: 'no-store' });
-  const json = await res.json();
-  const images = Array.isArray(json?.data) ? json.data : [];
-  const data = images.map(img => ({
-    id: img._id,
-    storedName: img.storedName,
-    uploadedBy: img.uploadedBy,
-    url: img.storedName?.startsWith('http')
-      ? img.storedName
-      : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${img.storedName}?t=${Date.now()}`,
-    createdAt: img.createdAt,
-    // add more fields if needed
-  }));
-
-
-  return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <ImageTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
-  );
+  return <ImagesPageClient canAdd={canAdd} canEdit={canEdit} />;
 }

--- a/app/admin/blogs/page.jsx
+++ b/app/admin/blogs/page.jsx
@@ -1,35 +1,10 @@
 import { cookies } from "next/headers";
-import { BlogTable } from "@/components/blogTable";
 import { hasServerPermission } from "@/helpers/permissions";
-import { getBlogs } from "@/app/actions/blogs";
+import BlogsPageClient from "./BlogsPageClient";
 
 export default async function Page() {
   const store = await cookies();
   const canAdd = hasServerPermission(store, 'blogs', 'write');
 
-  const blogs = await getBlogs();
-  const statusMap = { 1: 'draft', 2: 'published', 3: 'archived', 4: 'scheduled' };
-  const data = blogs.map(blog => {
-    const obj = {
-      id: blog.id,
-      title: blog.title,
-      status: statusMap[blog.status] || 'draft',
-      created_date: blog.created_date,
-      slug: blog.slug,
-    };
-    if (blog.banner) {
-      obj.banner = blog.banner?.startsWith('http')
-        ? blog.banner
-        : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/blogs/${blog.banner}`;
-    }
-    return obj;
-  });
-
-  return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <BlogTable data={data} canAdd={canAdd} />
-      </div>
-    </>
-  );
+  return <BlogsPageClient canAdd={canAdd} />;
 }

--- a/app/admin/departments/DepartmentsPageClient.jsx
+++ b/app/admin/departments/DepartmentsPageClient.jsx
@@ -1,0 +1,24 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { DepartmentTable } from '@/components/departmentTable';
+
+export default function DepartmentsPageClient({ token, canAdd }) {
+  const { data, loading } = useCachedApi('departments', async () => {
+    const res = await fetch('/api/v1/admin/departments', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const json = await res.json();
+    const depts = Array.isArray(json?.data) ? json.data : [];
+    return depts.map(d => ({ id: d._id, name: d.name }));
+  });
+
+  if (loading || !data) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <DepartmentTable data={data} canAdd={canAdd} />
+    </div>
+  );
+}

--- a/app/admin/departments/DepartmentsPageClient.jsx
+++ b/app/admin/departments/DepartmentsPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { DepartmentTable } from '@/components/departmentTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function DepartmentsPageClient({ token, canAdd }) {
   const { data, loading } = useCachedApi('departments', async () => {
@@ -13,7 +14,7 @@ export default function DepartmentsPageClient({ token, canAdd }) {
   });
 
   if (loading || !data) {
-    return <div className="p-4">Loading...</div>;
+    return <TableSkeleton />;
   }
 
   return (

--- a/app/admin/departments/page.jsx
+++ b/app/admin/departments/page.jsx
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { DepartmentTable } from "@/components/departmentTable";
 import { hasServerPermission } from "@/helpers/permissions";
+import DepartmentsPageClient from "./DepartmentsPageClient";
 
 export default async function Page() {
   const store = await cookies();
@@ -12,19 +12,7 @@ export default async function Page() {
 
   const canAdd = hasServerPermission(store, 'departments', 'write');
 
-  const base = process.env.NEXT_PUBLIC_BASE_URL || '';
   const token = store.get("token")?.value || '';
-  const res = await fetch(`${base}/api/v1/admin/departments`, {
-    cache: 'no-store',
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await res.json();
-  const depts = Array.isArray(json?.data) ? json.data : [];
-  const data = depts.map(d => ({ id: d._id, name: d.name }));
 
-  return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      <DepartmentTable data={data} canAdd={canAdd} />
-    </div>
-  );
+  return <DepartmentsPageClient token={token} canAdd={canAdd} />;
 }

--- a/app/admin/leads/LeadsPageClient.jsx
+++ b/app/admin/leads/LeadsPageClient.jsx
@@ -1,0 +1,32 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { LeadTable } from '@/components/leadTable';
+
+export default function LeadsPageClient({ endpoint, cacheKey, statusValue }) {
+  const { data, loading } = useCachedApi(cacheKey, async () => {
+    const res = await fetch(endpoint);
+    const json = await res.json();
+    const leads = Array.isArray(json?.data) ? json.data : [];
+    const statusMap = { 1: 'upcoming', 2: 'career' };
+    return leads.map(lead => ({
+      id: lead._id,
+      contact_name: lead.contact_name,
+      mobile_number: lead.mobile_number,
+      email: lead.email,
+      organization: lead.organization,
+      requirements: lead.requirements,
+      status: statusMap[lead.status] || statusValue,
+      created_date: lead.created_date,
+      assign_to: lead.assign_to,
+      attachments: lead.attachments,
+    }));
+  });
+
+  if (loading || !data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <LeadTable data={data} />
+    </div>
+  );
+}

--- a/app/admin/leads/LeadsPageClient.jsx
+++ b/app/admin/leads/LeadsPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { LeadTable } from '@/components/leadTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function LeadsPageClient({ endpoint, cacheKey, statusValue }) {
   const { data, loading } = useCachedApi(cacheKey, async () => {
@@ -22,7 +23,7 @@ export default function LeadsPageClient({ endpoint, cacheKey, statusValue }) {
     }));
   });
 
-  if (loading || !data) return <div className="p-4">Loading...</div>;
+  if (loading || !data) return <TableSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/leads/career/page.jsx
+++ b/app/admin/leads/career/page.jsx
@@ -1,25 +1,11 @@
-import { LeadTable } from "@/components/leadTable";
+import LeadsPageClient from "../LeadsPageClient";
 
 export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/career`, { cache: 'no-store' });
-  const json = await res.json();
-  const leads = Array.isArray(json?.data) ? json.data : [];
-  const data = leads.map(lead => ({
-    id: lead._id,
-    contact_name: lead.contact_name,
-    mobile_number: lead.mobile_number,
-    email: lead.email,
-    organization: lead.organization,
-    requirements: lead.requirements,
-    status: 'career',
-    created_date: lead.created_date,
-    assign_to: lead.assign_to,
-    attachments: lead.attachments,
-  }));
-
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      <LeadTable data={data} />
-    </div>
+    <LeadsPageClient
+      endpoint="/api/v1/admin/leads/career"
+      cacheKey="leads-career"
+      statusValue="career"
+    />
   );
 }

--- a/app/admin/leads/page.jsx
+++ b/app/admin/leads/page.jsx
@@ -1,26 +1,11 @@
-import { LeadTable } from "@/components/leadTable";
+import LeadsPageClient from "./LeadsPageClient";
 
 export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/upcoming`, { cache: 'no-store' });
-  const json = await res.json();
-  const leads = Array.isArray(json?.data) ? json.data : [];
-  const statusMap = { 1: 'upcoming', 2: 'career' };
-  const data = leads.map(lead => ({
-    id: lead._id,
-    contact_name: lead.contact_name,
-    mobile_number: lead.mobile_number,
-    email: lead.email,
-    organization: lead.organization,
-    requirements: lead.requirements,
-    status: statusMap[lead.status] || 'upcoming',
-    created_date: lead.created_date,
-    assign_to: lead.assign_to,
-    attachments: lead.attachments,
-  }));
-
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      <LeadTable data={data} />
-    </div>
+    <LeadsPageClient
+      endpoint="/api/v1/admin/leads/upcoming"
+      cacheKey="leads-upcoming"
+      statusValue="upcoming"
+    />
   );
 }

--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -22,6 +22,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useApiCache } from "@/app/store/use-api-cache";
 import { Separator } from "@/components/ui/separator";
 
 const defaultMeta = {
@@ -119,6 +120,8 @@ export default function EditStaticMetaForm({ meta }) {
       const json = await res.json();
       if (json.success) {
         toast.success("Meta updated successfully");
+        const clearData = useApiCache.getState().clearData;
+        clearData("static-meta");
       } else {
         toast.error(json.error || "Failed to update meta");
       }

--- a/app/admin/meta/static/StaticMetaPageClient.jsx
+++ b/app/admin/meta/static/StaticMetaPageClient.jsx
@@ -1,0 +1,39 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import EditStaticMetaForm from './EditStaticMetaForm';
+
+export default function StaticMetaPageClient() {
+  const { data: meta, loading } = useCachedApi('static-meta', async () => {
+    const res = await fetch('/api/v1/admin/meta/static');
+    const json = await res.json();
+    const meta = json?.data || null;
+    const toUrl = (name) =>
+      name && !name.startsWith('http')
+        ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${name}`
+        : name;
+    if (meta) {
+      meta.appleWebApp.startupImage.mainImageUrl = toUrl(
+        meta.appleWebApp.startupImage.mainImageUrl
+      );
+      meta.appleWebApp.startupImage.url = toUrl(meta.appleWebApp.startupImage.url);
+      meta.icons.icon = meta.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }));
+      meta.icons.shortcut = toUrl(meta.icons.shortcut);
+      meta.icons.apple = toUrl(meta.icons.apple);
+      meta.icons.other = meta.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }));
+      meta.twitter.images = meta.twitter.images.map(toUrl);
+      meta.openGraph.images = meta.openGraph.images.map((img) => ({
+        ...img,
+        url: toUrl(img.url),
+      }));
+    }
+    return meta;
+  });
+
+  if (loading) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="w-full p-4">
+      <EditStaticMetaForm meta={meta} />
+    </div>
+  );
+}

--- a/app/admin/meta/static/StaticMetaPageClient.jsx
+++ b/app/admin/meta/static/StaticMetaPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import EditStaticMetaForm from './EditStaticMetaForm';
+import { FormSkeleton } from '@/components/skeleton/form-skeleton';
 
 export default function StaticMetaPageClient() {
   const { data: meta, loading } = useCachedApi('static-meta', async () => {
@@ -29,7 +30,7 @@ export default function StaticMetaPageClient() {
     return meta;
   });
 
-  if (loading) return <div className="p-4">Loading...</div>;
+  if (loading) return <FormSkeleton rows={4} />;
 
   return (
     <div className="w-full p-4">

--- a/app/admin/meta/static/page.jsx
+++ b/app/admin/meta/static/page.jsx
@@ -1,33 +1,5 @@
-import EditStaticMetaForm from './EditStaticMetaForm';
+import StaticMetaPageClient from './StaticMetaPageClient';
 
 export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/static`, { cache: 'no-store' });
-  const json = await res.json();
-  const meta = json?.data || null;
-
-  const toUrl = (name) =>
-    name && !name.startsWith('http')
-      ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${name}`
-      : name;
-  if (meta) {
-    meta.appleWebApp.startupImage.mainImageUrl = toUrl(
-      meta.appleWebApp.startupImage.mainImageUrl
-    );
-    meta.appleWebApp.startupImage.url = toUrl(meta.appleWebApp.startupImage.url);
-    meta.icons.icon = meta.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }));
-    meta.icons.shortcut = toUrl(meta.icons.shortcut);
-    meta.icons.apple = toUrl(meta.icons.apple);
-    meta.icons.other = meta.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }));
-    meta.twitter.images = meta.twitter.images.map(toUrl);
-    meta.openGraph.images = meta.openGraph.images.map((img) => ({
-      ...img,
-      url: toUrl(img.url),
-    }));
-  }
-
-  return (
-    <div className="w-full p-4">
-      <EditStaticMetaForm meta={meta} />
-    </div>
-  );
+  return <StaticMetaPageClient />;
 }

--- a/app/admin/newsletter/NewsletterPageClient.jsx
+++ b/app/admin/newsletter/NewsletterPageClient.jsx
@@ -1,0 +1,20 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { NewsletterTable } from '@/components/newsletterTable';
+
+export default function NewsletterPageClient() {
+  const { data, loading } = useCachedApi('newsletters', async () => {
+    const res = await fetch('/api/v1/admin/newsletters');
+    const json = await res.json();
+    const newsletters = Array.isArray(json?.data) ? json.data : [];
+    return newsletters.map(n => ({ id: n._id, email: n.email, createdAt: n.createdAt }));
+  });
+
+  if (loading || !data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <NewsletterTable data={data} />
+    </div>
+  );
+}

--- a/app/admin/newsletter/NewsletterPageClient.jsx
+++ b/app/admin/newsletter/NewsletterPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { NewsletterTable } from '@/components/newsletterTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function NewsletterPageClient() {
   const { data, loading } = useCachedApi('newsletters', async () => {
@@ -10,7 +11,7 @@ export default function NewsletterPageClient() {
     return newsletters.map(n => ({ id: n._id, email: n.email, createdAt: n.createdAt }));
   });
 
-  if (loading || !data) return <div className="p-4">Loading...</div>;
+  if (loading || !data) return <TableSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/newsletter/page.jsx
+++ b/app/admin/newsletter/page.jsx
@@ -1,18 +1,5 @@
-import { NewsletterTable } from "@/components/newsletterTable";
+import NewsletterPageClient from "./NewsletterPageClient";
 
 export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/newsletters`, { cache: 'no-store' });
-  const json = await res.json();
-  const newsletters = Array.isArray(json?.data) ? json.data : [];
-  const data = newsletters.map(n => ({
-    id: n._id,
-    email: n.email,
-    createdAt: n.createdAt,
-  }));
-
-  return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      <NewsletterTable data={data} />
-    </div>
-  );
+  return <NewsletterPageClient />;
 }

--- a/app/admin/redirections/RedirectionsPageClient.jsx
+++ b/app/admin/redirections/RedirectionsPageClient.jsx
@@ -1,0 +1,29 @@
+"use client";
+import { useCachedApi } from '@/hooks/use-cached-api';
+import { RedirectionTable } from '@/components/redirectionTable';
+
+export default function RedirectionsPageClient({ token, canAdd, canEdit, canDelete }) {
+  const { data, loading } = useCachedApi('redirections', async () => {
+    const res = await fetch('/api/v1/admin/redirections', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const json = await res.json();
+    const redirections = Array.isArray(json?.data) ? json.data : [];
+    return redirections.map(r => ({
+      id: r.id,
+      from: r.from,
+      to: r.to,
+      methodCode: r.methodCode,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }));
+  });
+
+  if (loading || !data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <RedirectionTable data={data} canAdd={canAdd} canEdit={canEdit} canDelete={canDelete} />
+    </div>
+  );
+}

--- a/app/admin/redirections/RedirectionsPageClient.jsx
+++ b/app/admin/redirections/RedirectionsPageClient.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCachedApi } from '@/hooks/use-cached-api';
 import { RedirectionTable } from '@/components/redirectionTable';
+import { TableSkeleton } from '@/components/skeleton/table-skeleton';
 
 export default function RedirectionsPageClient({ token, canAdd, canEdit, canDelete }) {
   const { data, loading } = useCachedApi('redirections', async () => {
@@ -19,7 +20,7 @@ export default function RedirectionsPageClient({ token, canAdd, canEdit, canDele
     }));
   });
 
-  if (loading || !data) return <div className="p-4">Loading...</div>;
+  if (loading || !data) return <TableSkeleton />;
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/redirections/page.jsx
+++ b/app/admin/redirections/page.jsx
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { RedirectionTable } from "@/components/redirectionTable";
 import { hasServerPermission } from "@/helpers/permissions";
+import RedirectionsPageClient from "./RedirectionsPageClient";
 
 export default async function Page() {
   const store = await cookies();
@@ -14,31 +14,14 @@ export default async function Page() {
   const canEdit = hasServerPermission(store, 'redirections', 'edit');
   const canDelete = hasServerPermission(store, 'redirections', 'delete');
 
-  const base = process.env.NEXT_PUBLIC_BASE_URL || '';
   const token = store.get("token")?.value || '';
-  const res = await fetch(`${base}/api/v1/admin/redirections`, {
-    cache: 'no-store',
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await res.json();
-  const redirections = Array.isArray(json?.data) ? json.data : [];
-  const data = redirections.map(r => ({
-    id: r.id,
-    from: r.from,
-    to: r.to,
-    methodCode: r.methodCode,
-    createdAt: r.createdAt,
-    updatedAt: r.updatedAt,
-  }));
 
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      <RedirectionTable
-        data={data}
-        canAdd={canAdd}
-        canEdit={canEdit}
-        canDelete={canDelete}
-      />
-    </div>
+    <RedirectionsPageClient
+      token={token}
+      canAdd={canAdd}
+      canEdit={canEdit}
+      canDelete={canDelete}
+    />
   );
 }

--- a/app/store/use-api-cache.js
+++ b/app/store/use-api-cache.js
@@ -1,3 +1,4 @@
+"use client";
 import { create } from 'zustand'
 
 export const useApiCache = create((set, get) => ({

--- a/app/store/use-api-cache.js
+++ b/app/store/use-api-cache.js
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+export const useApiCache = create((set, get) => ({
+  cache: {},
+  getData: (key) => get().cache[key],
+  setData: (key, data) => set((state) => ({ cache: { ...state.cache, [key]: data } })),
+  clearData: (key) => set((state) => {
+    if (!key) return { cache: {} };
+    const newCache = { ...state.cache };
+    delete newCache[key];
+    return { cache: newCache };
+  })
+}));

--- a/app/store/use-api-cache.js
+++ b/app/store/use-api-cache.js
@@ -1,14 +1,20 @@
 "use client";
-import { create } from 'zustand'
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-export const useApiCache = create((set, get) => ({
-  cache: {},
-  getData: (key) => get().cache[key],
-  setData: (key, data) => set((state) => ({ cache: { ...state.cache, [key]: data } })),
-  clearData: (key) => set((state) => {
-    if (!key) return { cache: {} };
-    const newCache = { ...state.cache };
-    delete newCache[key];
-    return { cache: newCache };
-  })
-}));
+export const useApiCache = create(persist(
+  (set, get) => ({
+    cache: {},
+    getData: (key) => get().cache[key],
+    setData: (key, data) =>
+      set((state) => ({ cache: { ...state.cache, [key]: data } })),
+    clearData: (key) =>
+      set((state) => {
+        if (!key) return { cache: {} };
+        const newCache = { ...state.cache };
+        delete newCache[key];
+        return { cache: newCache };
+      }),
+  }),
+  { name: 'api-cache' }
+));

--- a/app/store/use-team-store.js
+++ b/app/store/use-team-store.js
@@ -1,6 +1,13 @@
-import { create } from 'zustand'
+"use client";
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-export const useTeamStore = create((set) => ({
-  activeTeam: null,
-  setActiveTeam: (team) => set({ activeTeam: team }),
-}))
+export const useTeamStore = create(
+  persist(
+    (set) => ({
+      activeTeam: null,
+      setActiveTeam: (team) => set({ activeTeam: team }),
+    }),
+    { name: 'active-team' }
+  )
+);

--- a/components/adminTable.jsx
+++ b/components/adminTable.jsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useApiCache } from "@/app/store/use-api-cache";
 import { hasClientPermission } from "@/helpers/permissions";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -45,6 +46,7 @@ import Link from "next/link";
 
 function AdminActions({ admin }) {
   const router = useRouter();
+  const clearData = useApiCache((state) => state.clearData);
   const [openDelete, setOpenDelete] = React.useState(false);
 
   const handleDelete = async () => {
@@ -54,6 +56,7 @@ function AdminActions({ admin }) {
       if (data.success) {
         toast.success('Admin deleted');
         if (data.notice) toast.info(data.notice);
+        clearData("admins");
         router.refresh();
       } else {
         toast.error(data.error || 'Failed to delete');

--- a/components/authorTable.jsx
+++ b/components/authorTable.jsx
@@ -41,6 +41,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import apiFetch from "@/helpers/apiFetch"
+import { useApiCache } from "@/app/store/use-api-cache"
 
 function AuthorActions({ author, canEdit }) {
   const router = useRouter()
@@ -56,6 +57,8 @@ function AuthorActions({ author, canEdit }) {
       const data = await res.json()
       if (data.success) {
         toast.success('Status updated')
+        const clearData = useApiCache.getState().clearData
+        clearData('authors')
         router.refresh()
       } else {
         toast.error(data.error || 'Failed to update status')

--- a/components/blogTable.jsx
+++ b/components/blogTable.jsx
@@ -49,6 +49,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useApiCache } from "@/app/store/use-api-cache";
 import RedirectionForm from "@/components/RedirectionForm";
 import { deleteRedirection } from "@/actions/redirections";
 
@@ -80,6 +81,8 @@ function BlogActions({ blog }) {
       const data = await res.json();
       if (data.success) {
         toast.success("Status updated");
+        const clearData = useApiCache.getState().clearData;
+        clearData("blogs");
         router.refresh();
       } else {
         toast.error(data.error || "Failed to update status");
@@ -113,6 +116,8 @@ function BlogActions({ blog }) {
       const data = await res.json();
       if (data.success) {
         toast.success(data.message || "Blog deleted");
+        const clearData = useApiCache.getState().clearData;
+        clearData("blogs");
         router.refresh();
       } else {
         toast.error(data.error || "Failed to delete blog");

--- a/components/categoryTable.jsx
+++ b/components/categoryTable.jsx
@@ -38,6 +38,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useApiCache } from "@/app/store/use-api-cache";
 
 function CategoryActions({ category, canEdit }) {
   const router = useRouter();
@@ -53,6 +54,8 @@ function CategoryActions({ category, canEdit }) {
       const data = await res.json();
       if (data.success) {
         toast.success('Status updated');
+        const clearData = useApiCache.getState().clearData;
+        clearData('categories');
         router.refresh();
       } else {
         toast.error(data.error || 'Failed to update status');

--- a/components/delete-department-buttons.jsx
+++ b/components/delete-department-buttons.jsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useApiCache } from "@/app/store/use-api-cache";
 
 import React from "react";
 
@@ -54,6 +55,8 @@ export default function DeleteDepartmentButtons({
       const data = await res.json();
       if (data.success) {
         toast.success("Department deleted");
+        const clearData = useApiCache.getState().clearData;
+        clearData("departments");
         router.refresh();
       } else {
         toast.error(data.error || "Failed to delete department");

--- a/components/leadTable.jsx
+++ b/components/leadTable.jsx
@@ -45,6 +45,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useApiCache } from "@/app/store/use-api-cache";
 import { getPublicUrl } from "@/lib/s3";
 
 function LeadActions({ lead }) {
@@ -62,6 +63,8 @@ function LeadActions({ lead }) {
       const data = await res.json();
       if (data.success) {
         toast.success("Status updated");
+        const clearData = useApiCache.getState().clearData;
+        clearData("leads");
         router.refresh();
       } else {
         toast.error(data.error || "Failed to update status");

--- a/components/newsletterTable.jsx
+++ b/components/newsletterTable.jsx
@@ -43,6 +43,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useApiCache } from "@/app/store/use-api-cache";
 
 function NewsletterActions({ newsletter }) {
   const router = useRouter();
@@ -56,6 +57,8 @@ function NewsletterActions({ newsletter }) {
       const data = await res.json();
       if (data.success) {
         toast.success("Deleted");
+        const clearData = useApiCache.getState().clearData;
+        clearData("newsletters");
         router.refresh();
       } else {
         toast.error(data.error || "Failed to delete");

--- a/components/redirectionTable.jsx
+++ b/components/redirectionTable.jsx
@@ -35,6 +35,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useApiCache } from "@/app/store/use-api-cache";
 import {
   Dialog,
   DialogTrigger,
@@ -60,6 +61,8 @@ function RedirectionActions({ redirection, canEdit, canDelete }) {
       if (data.success) {
         toast.success("Redirection deleted");
         if (data.notice) toast.info(data.notice);
+        const clearData = useApiCache.getState().clearData;
+        clearData("redirections");
         setOpen(false);
         router.refresh();
       } else {

--- a/components/skeleton/editor-skeleton.jsx
+++ b/components/skeleton/editor-skeleton.jsx
@@ -1,0 +1,6 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function EditorSkeleton() {
+  return <Skeleton className="w-full h-96" />;
+}

--- a/components/skeleton/form-skeleton.jsx
+++ b/components/skeleton/form-skeleton.jsx
@@ -1,0 +1,12 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function FormSkeleton({ rows = 4 }) {
+  return (
+    <div className="p-4 space-y-4">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/components/skeleton/table-skeleton.jsx
+++ b/components/skeleton/table-skeleton.jsx
@@ -1,0 +1,12 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function TableSkeleton({ rows = 5 }) {
+  return (
+    <div className="p-4 space-y-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-8 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/hooks/use-cached-api.js
+++ b/hooks/use-cached-api.js
@@ -1,0 +1,34 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useApiCache } from '@/app/store/use-api-cache';
+
+export function useCachedApi(key, fetcher) {
+  const data = useApiCache((state) => state.getData(key));
+  const setData = useApiCache((state) => state.setData);
+  const [loading, setLoading] = useState(!data);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (data) {
+      setLoading(false);
+      return;
+    }
+    let ignore = false;
+    async function load() {
+      try {
+        const result = await fetcher();
+        if (!ignore) {
+          setData(key, result);
+        }
+      } catch (e) {
+        if (!ignore) setError(e);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+    load();
+    return () => { ignore = true; };
+  }, [data, key, fetcher, setData]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- implement zustand `useApiCache` store
- add `useCachedApi` hook for reusing cached API data
- update Admin table to clear cache after delete
- convert admin list page to client component using the cache

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686428485be083288d1e80397764496d