### PR TITLE
Add loading skeletons for category pages

### DIFF
--- a/app/admin/blogs/categories/[id]/edit/loading.jsx
+++ b/app/admin/blogs/categories/[id]/edit/loading.jsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4 space-y-4">
+      <Skeleton className="h-8 w-40" />
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/loading.jsx
+++ b/app/admin/blogs/categories/[id]/loading.jsx
@@ -1,14 +1,27 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function Loading() {
   return (
-    <div className="w-full p-4 space-y-4">
-      <Skeleton className="h-8 w-40" />
-      <div className="space-y-2">
-        {[...Array(6)].map((_, i) => (
-          <Skeleton key={i} className="h-4 w-full" />
-        ))}
-      </div>
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/admin/blogs/categories/[id]/loading.jsx
+++ b/app/admin/blogs/categories/[id]/loading.jsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4 space-y-4">
+      <Skeleton className="h-8 w-40" />
+      <div className="space-y-2">
+        {[...Array(6)].map((_, i) => (
+          <Skeleton key={i} className="h-4 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/add/loading.jsx
+++ b/app/admin/blogs/categories/add/loading.jsx
@@ -18,14 +18,12 @@ export default function Loading() {
             <div className="space-y-2">
               <Skeleton className="h-4 w-32" />
               <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-3 w-40" />
             </div>
             <div className="space-y-2">
               <Skeleton className="h-4 w-32" />
               <Skeleton className="h-[120px] w-full" />
-            </div>
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-10 w-40" />
+              <Skeleton className="h-3 w-64" />
             </div>
             <div className="flex justify-end gap-4">
               <Skeleton className="h-10 w-32" />

--- a/app/admin/blogs/categories/loading.jsx
+++ b/app/admin/blogs/categories/loading.jsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      {[...Array(5)].map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/loading.jsx
+++ b/app/admin/blogs/categories/loading.jsx
@@ -1,11 +1,42 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export default function Loading() {
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-      {[...Array(5)].map((_, i) => (
-        <Skeleton key={i} className="h-10 w-full" />
-      ))}
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(6)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(6)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create loading states for admin category pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864cebdfd888328a1ce9a14a0712267