### PR TITLE
Add loading skeletons for category pages

### DIFF
--- a/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
+++ b/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
@@ -24,7 +24,8 @@ import {
 } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateCategory } from "@/app/actions/categories";
-import { useCategory, useCategories } from "@/hooks/use-categories";
+import { useCategory } from "@/hooks/use-categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -38,8 +39,8 @@ const categoryFormSchema = z.object({
 
 export default function EditCategoryForm({ category }) {
   const router = useRouter();
-  const { refresh: refreshCategory } = useCategory(category._id);
-  const { refresh: refreshCategories } = useCategories();
+  useCategory(category._id); // ensure detail cached
+  const updateCat = useCategoryStore(state => state.updateCategory);
   const form = useForm({
     resolver: zodResolver(categoryFormSchema),
     defaultValues: {
@@ -57,8 +58,9 @@ export default function EditCategoryForm({ category }) {
       formData.append("status", String(data.status || 1));
       const result = await updateCategory(category._id, formData);
       if (result.success) {
-        refreshCategory();
-        refreshCategories();
+        if (result.data) {
+          updateCat(category._id, result.data);
+        }
         toast.success("Category updated successfully!");
         router.push(`/admin/blogs/categories/${category._id}`);
       } else {

--- a/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
+++ b/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateCategory } from "@/app/actions/categories";
+import { useCategory, useCategories } from "@/hooks/use-categories";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -37,6 +38,8 @@ const categoryFormSchema = z.object({
 
 export default function EditCategoryForm({ category }) {
   const router = useRouter();
+  const { refresh: refreshCategory } = useCategory(category._id);
+  const { refresh: refreshCategories } = useCategories();
   const form = useForm({
     resolver: zodResolver(categoryFormSchema),
     defaultValues: {
@@ -54,9 +57,10 @@ export default function EditCategoryForm({ category }) {
       formData.append("status", String(data.status || 1));
       const result = await updateCategory(category._id, formData);
       if (result.success) {
+        refreshCategory();
+        refreshCategories();
         toast.success("Category updated successfully!");
         router.push(`/admin/blogs/categories/${category._id}`);
-        router.refresh();
       } else {
         toast.error(result.error || "Failed to update category");
       }

--- a/app/admin/blogs/categories/[id]/edit/loading.jsx
+++ b/app/admin/blogs/categories/[id]/edit/loading.jsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/edit/page.jsx
+++ b/app/admin/blogs/categories/[id]/edit/page.jsx
@@ -1,10 +1,12 @@
 "use client";
 import EditCategoryForm from "./EditCategoryForm";
 import { useCategory } from "@/hooks/use-categories";
+import { use as usePromise } from "react";
 import CategoryEditSkeleton from "@/components/skeleton/category-edit-skeleton";
 
 export default function Page({ params }) {
-  const { category, loading } = useCategory(params.id);
+  const { id } = usePromise(params);
+  const { category, loading } = useCategory(id);
 
   if (loading && !category) {
     return <CategoryEditSkeleton />;

--- a/app/admin/blogs/categories/[id]/edit/page.jsx
+++ b/app/admin/blogs/categories/[id]/edit/page.jsx
@@ -1,20 +1,22 @@
+"use client";
 import EditCategoryForm from "./EditCategoryForm";
+import { useCategory } from "@/hooks/use-categories";
+import CategoryEditSkeleton from "@/components/skeleton/category-edit-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const category = json?.data;
+export default function Page({ params }) {
+  const { category, loading } = useCategory(params.id);
 
-  if (!category) {
+  if (loading && !category) {
+    return <CategoryEditSkeleton />;
+  }
+
+  if (!loading && !category) {
     return <div className="p-4">Category not found</div>;
   }
 
   return (
-    <>
-      <div className="w-full p-4">
-        <EditCategoryForm category={category} />
-      </div>
-    </>
+    <div className="w-full p-4">
+      <EditCategoryForm category={category} />
+    </div>
   );
 }

--- a/app/admin/blogs/categories/[id]/loading.jsx
+++ b/app/admin/blogs/categories/[id]/loading.jsx
@@ -1,0 +1,27 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/page.jsx
+++ b/app/admin/blogs/categories/[id]/page.jsx
@@ -1,49 +1,48 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import DeleteCategoryButtons from "@/components/delete-category-buttons";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { useCategory } from "@/hooks/use-categories";
+import CategoryDetailSkeleton from "@/components/skeleton/category-detail-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const category = json?.data;
-
-  if (!category) {
-    return (
-      <div className="p-4">Category not found</div>
-    );
-  }
-
+export default function Page({ params }) {
+  const { category, loading } = useCategory(params.id);
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
 
+  if (loading && !category) {
+    return <CategoryDetailSkeleton />;
+  }
+
+  if (!loading && !category) {
+    return <div className="p-4">Category not found</div>;
+  }
+
   return (
-    <>
-      <div className="w-full p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Category Details</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2 text-sm">
-              <p><strong>Name:</strong> {category.category_name}</p>
-              <p><strong>Description:</strong> {category.description}</p>
-              <p><strong>Status:</strong> {statusMap[category.status]}</p>
-              <p><strong>Blogs:</strong> {category.blog_count}</p>
-              <p><strong>Created:</strong> {new Date(category.created_date).toLocaleString()}</p>
-              {category.deleted_at && (
-                <p><strong>Deleted:</strong> {new Date(category.deleted_at).toLocaleString()}</p>
-              )}
-            </div>
-            <div className="mt-4 flex gap-2 justify-end">
-              <Link href={`/admin/blogs/categories/${category._id}/edit`}>
-                <Button type="button">Edit</Button>
-              </Link>
-              <DeleteCategoryButtons id={category._id} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Category Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            <p><strong>Name:</strong> {category.category_name}</p>
+            <p><strong>Description:</strong> {category.description}</p>
+            <p><strong>Status:</strong> {statusMap[category.status]}</p>
+            <p><strong>Blogs:</strong> {category.blog_count}</p>
+            <p><strong>Created:</strong> {new Date(category.created_date).toLocaleString()}</p>
+            {category.deleted_at && (
+              <p><strong>Deleted:</strong> {new Date(category.deleted_at).toLocaleString()}</p>
+            )}
+          </div>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Link href={`/admin/blogs/categories/${category._id}/edit`}>
+              <Button type="button">Edit</Button>
+            </Link>
+            <DeleteCategoryButtons id={category._id} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/app/admin/blogs/categories/[id]/page.jsx
+++ b/app/admin/blogs/categories/[id]/page.jsx
@@ -4,10 +4,12 @@ import DeleteCategoryButtons from "@/components/delete-category-buttons";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { useCategory } from "@/hooks/use-categories";
+import { use as usePromise } from "react";
 import CategoryDetailSkeleton from "@/components/skeleton/category-detail-skeleton";
 
 export default function Page({ params }) {
-  const { category, loading } = useCategory(params.id);
+  const { id } = usePromise(params);
+  const { category, loading } = useCategory(id);
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
 
   if (loading && !category) {

--- a/app/admin/blogs/categories/add/loading.jsx
+++ b/app/admin/blogs/categories/add/loading.jsx
@@ -1,0 +1,36 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-3 w-40" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+              <Skeleton className="h-3 w-64" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/add/page.jsx
+++ b/app/admin/blogs/categories/add/page.jsx
@@ -24,6 +24,7 @@ import * as z from "zod";
 import { toast } from "sonner";
 import { createCategory } from "@/app/actions/categories";
 import { useCategoryStore } from "@/app/store/use-category-store";
+import { useCategories } from "@/hooks/use-categories";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -45,6 +46,7 @@ export default function Page() {
   const categories = useCategoryStore((state) => state.categories);
   const setCategories = useCategoryStore((state) => state.setCategories);
   const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
+  const { refresh } = useCategories();
   async function onSubmit(data) {
     try {
       const formData = new FormData();
@@ -56,6 +58,7 @@ export default function Page() {
           setCategoryDetail(result.data);
           setCategories(categories ? [result.data, ...categories] : [result.data]);
         }
+        refresh();
         toast.success("Category created successfully!");
         form.reset();
       } else {

--- a/app/admin/blogs/categories/add/page.jsx
+++ b/app/admin/blogs/categories/add/page.jsx
@@ -23,6 +23,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
 import { createCategory } from "@/app/actions/categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -41,6 +42,9 @@ export default function Page() {
       description: "",
     },
   });
+  const categories = useCategoryStore((state) => state.categories);
+  const setCategories = useCategoryStore((state) => state.setCategories);
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
   async function onSubmit(data) {
     try {
       const formData = new FormData();
@@ -48,6 +52,10 @@ export default function Page() {
       formData.append('description', data.description.trim());
       const result = await createCategory(formData);
       if (result.success) {
+        if (result.data) {
+          setCategoryDetail(result.data);
+          setCategories(categories ? [result.data, ...categories] : [result.data]);
+        }
         toast.success("Category created successfully!");
         form.reset();
       } else {

--- a/app/admin/blogs/categories/add/page.jsx
+++ b/app/admin/blogs/categories/add/page.jsx
@@ -24,7 +24,6 @@ import * as z from "zod";
 import { toast } from "sonner";
 import { createCategory } from "@/app/actions/categories";
 import { useCategoryStore } from "@/app/store/use-category-store";
-import { useCategories } from "@/hooks/use-categories";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -46,7 +45,6 @@ export default function Page() {
   const categories = useCategoryStore((state) => state.categories);
   const setCategories = useCategoryStore((state) => state.setCategories);
   const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
-  const { refresh } = useCategories();
   async function onSubmit(data) {
     try {
       const formData = new FormData();
@@ -58,7 +56,6 @@ export default function Page() {
           setCategoryDetail(result.data);
           setCategories(categories ? [result.data, ...categories] : [result.data]);
         }
-        refresh();
         toast.success("Category created successfully!");
         form.reset();
       } else {

--- a/app/admin/blogs/categories/loading.jsx
+++ b/app/admin/blogs/categories/loading.jsx
@@ -1,0 +1,42 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(6)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(6)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/page.jsx
+++ b/app/admin/blogs/categories/page.jsx
@@ -1,16 +1,16 @@
+"use client";
 import { CategoryTable } from "@/components/categoryTable";
-import { cookies } from "next/headers";
-import { hasServerPermission } from "@/helpers/permissions";
+import CategoryTableSkeleton from "@/components/skeleton/category-table-skeleton";
+import { useCategories } from "@/hooks/use-categories";
+import { usePermission } from "@/hooks/use-permission";
 
-export default async function Page() {
-  const store = await cookies();
-  const canAdd = hasServerPermission(store, 'categories', 'write');
-  const canEdit = hasServerPermission(store, 'categories', 'edit');
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories`, { cache: 'no-store' });
-  const json = await res.json();
-  const categories = Array.isArray(json?.data) ? json.data : [];
+export default function Page() {
+  const { categories, loading } = useCategories();
+  const canAdd = usePermission('categories', 'write');
+  const canEdit = usePermission('categories', 'edit');
+
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
-  const data = categories.map(cat => ({
+  const data = categories ? categories.map(cat => ({
     id: cat._id,
     category_name: cat.category_name,
     description: cat.description,
@@ -18,13 +18,15 @@ export default async function Page() {
     created_date: cat.created_date,
     modified_date: cat.modified_date,
     blog_count: cat.blog_count,
-  }));
+  })) : [];
+
+  if (loading && !categories) {
+    return <CategoryTableSkeleton />;
+  }
 
   return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
   );
 }

--- a/app/api/v1/admin/admins/me/route.js
+++ b/app/api/v1/admin/admins/me/route.js
@@ -7,7 +7,7 @@ import Admin from '@/app/models/Admin';
 export async function GET(req) {
   let token = extractToken(req.headers);
   if (!token) {
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     token = cookieStore.get('token')?.value || null;
   }
   if (!token) {

--- a/app/api/v1/admin/departments/[id]/route.js
+++ b/app/api/v1/admin/departments/[id]/route.js
@@ -6,10 +6,11 @@ import { ensurePermission } from '@/lib/rbac';
 import { syncAdminsFromDB } from '@/app/lib/adminsFile';
 
 export async function GET(req, { params }) {
+  const { id } = await params;
   const admin = await ensurePermission(req, 'departments', 'read');
   if (!admin) return NextResponse.json({ success: false, error: 'Permission denied' }, { status: 403 });
   await connectDB();
-  const dept = await Department.findById(params.id).lean();
+  const dept = await Department.findById(id).lean();
   if (!dept) return NextResponse.json({ success: false, error: 'Department not found' }, { status: 404 });
   return NextResponse.json({ success: true, data: dept });
 }

--- a/app/store/use-category-store.js
+++ b/app/store/use-category-store.js
@@ -8,4 +8,10 @@ export const useCategoryStore = create((set) => ({
     set((state) => ({
       categoryDetails: { ...state.categoryDetails, [cat._id || cat.id]: cat },
     })),
+  clearCategories: () => set({ categories: null }),
+  removeCategory: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.categoryDetails
+      return { categoryDetails: rest }
+    }),
 }))

--- a/app/store/use-category-store.js
+++ b/app/store/use-category-store.js
@@ -8,6 +8,21 @@ export const useCategoryStore = create((set) => ({
     set((state) => ({
       categoryDetails: { ...state.categoryDetails, [cat._id || cat.id]: cat },
     })),
+  updateCategory: (id, updates) =>
+    set((state) => {
+      const categories = state.categories
+        ? state.categories.map((c) =>
+            (c._id || c.id) === id ? { ...c, ...updates } : c
+          )
+        : null;
+      const detail = state.categoryDetails[id];
+      return {
+        categories,
+        categoryDetails: detail
+          ? { ...state.categoryDetails, [id]: { ...detail, ...updates } }
+          : state.categoryDetails,
+      };
+    }),
   clearCategories: () => set({ categories: null }),
   removeCategory: (id) =>
     set((state) => {

--- a/app/store/use-category-store.js
+++ b/app/store/use-category-store.js
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+export const useCategoryStore = create((set) => ({
+  categories: null,
+  categoryDetails: {},
+  setCategories: (cats) => set({ categories: cats }),
+  setCategoryDetail: (cat) =>
+    set((state) => ({
+      categoryDetails: { ...state.categoryDetails, [cat._id || cat.id]: cat },
+    })),
+}))

--- a/components/category-store-initializer.jsx
+++ b/components/category-store-initializer.jsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect } from "react";
+import { useCategoryStore } from "@/app/store/use-category-store";
+
+export default function CategoryStoreInitializer({ categories, category }) {
+  const setCategories = useCategoryStore((state) => state.setCategories);
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
+
+  useEffect(() => {
+    if (categories) {
+      setCategories(categories);
+    }
+  }, [categories, setCategories]);
+
+  useEffect(() => {
+    if (category) {
+      setCategoryDetail(category);
+    }
+  }, [category, setCategoryDetail]);
+
+  return null;
+}

--- a/components/categoryTable.jsx
+++ b/components/categoryTable.jsx
@@ -38,9 +38,11 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useCategories } from "@/hooks/use-categories";
 
 function CategoryActions({ category, canEdit }) {
   const router = useRouter();
+  const { refresh } = useCategories();
 
   const handleStatusChange = async (status) => {
     try {
@@ -53,6 +55,7 @@ function CategoryActions({ category, canEdit }) {
       const data = await res.json();
       if (data.success) {
         toast.success('Status updated');
+        refresh();
         router.refresh();
       } else {
         toast.error(data.error || 'Failed to update status');

--- a/components/categoryTable.jsx
+++ b/components/categoryTable.jsx
@@ -35,14 +35,12 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
-import { useCategories } from "@/hooks/use-categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 function CategoryActions({ category, canEdit }) {
-  const router = useRouter();
-  const { refresh } = useCategories();
+  const updateCategory = useCategoryStore(state => state.updateCategory);
 
   const handleStatusChange = async (status) => {
     try {
@@ -55,8 +53,7 @@ function CategoryActions({ category, canEdit }) {
       const data = await res.json();
       if (data.success) {
         toast.success('Status updated');
-        refresh();
-        router.refresh();
+        updateCategory(category.id, { status });
       } else {
         toast.error(data.error || 'Failed to update status');
       }

--- a/components/delete-category-buttons.jsx
+++ b/components/delete-category-buttons.jsx
@@ -5,6 +5,7 @@ import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, Dialo
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useCategory, useCategories } from "@/hooks/use-categories";
 import { Copy } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
@@ -14,6 +15,8 @@ export default function DeleteCategoryButtons({ id }) {
   const [open, setOpen] = useState(false);
   const [blogs, setBlogs] = useState(null);
   const [loading, setLoading] = useState(false);
+  const { refresh: refreshCategory } = useCategory(id);
+  const { refresh: refreshCategories } = useCategories();
 
   const handleOpen = async () => {
     setOpen(true);
@@ -33,6 +36,8 @@ export default function DeleteCategoryButtons({ id }) {
       });
       const data = await res.json();
       if (data.success) {
+        refreshCategory();
+        refreshCategories();
         toast.success(data.message || "Category deleted");
         router.push("/admin/blogs/categories");
       } else {

--- a/components/delete-category-buttons.jsx
+++ b/components/delete-category-buttons.jsx
@@ -5,7 +5,8 @@ import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, Dialo
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
-import { useCategory, useCategories } from "@/hooks/use-categories";
+import { useCategory } from "@/hooks/use-categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 import { Copy } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
@@ -15,8 +16,8 @@ export default function DeleteCategoryButtons({ id }) {
   const [open, setOpen] = useState(false);
   const [blogs, setBlogs] = useState(null);
   const [loading, setLoading] = useState(false);
-  const { refresh: refreshCategory } = useCategory(id);
-  const { refresh: refreshCategories } = useCategories();
+  useCategory(id); // preload for cache update
+  const removeCategory = useCategoryStore(state => state.removeCategory);
 
   const handleOpen = async () => {
     setOpen(true);
@@ -36,8 +37,7 @@ export default function DeleteCategoryButtons({ id }) {
       });
       const data = await res.json();
       if (data.success) {
-        refreshCategory();
-        refreshCategories();
+        removeCategory(id);
         toast.success(data.message || "Category deleted");
         router.push("/admin/blogs/categories");
       } else {

--- a/components/skeleton/category-detail-skeleton.jsx
+++ b/components/skeleton/category-detail-skeleton.jsx
@@ -1,0 +1,28 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function CategoryDetailSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/category-edit-skeleton.jsx
+++ b/components/skeleton/category-edit-skeleton.jsx
@@ -1,0 +1,39 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function CategoryEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/category-table-skeleton.jsx
+++ b/components/skeleton/category-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function CategoryTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(6)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(6)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/hooks/use-categories.js
+++ b/hooks/use-categories.js
@@ -1,11 +1,16 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import apiFetch from '@/helpers/apiFetch'
 import { useCategoryStore } from '@/app/store/use-category-store'
 
 export function useCategories() {
   const categories = useCategoryStore(state => state.categories)
   const setCategories = useCategoryStore(state => state.setCategories)
+  const clearCategories = useCategoryStore(state => state.clearCategories)
   const [loading, setLoading] = useState(false)
+
+  const refresh = useCallback(() => {
+    clearCategories()
+  }, [clearCategories])
 
   useEffect(() => {
     if (!categories && !loading) {
@@ -21,13 +26,18 @@ export function useCategories() {
     }
   }, [categories, loading, setCategories])
 
-  return { categories, loading }
+  return { categories, loading, refresh }
 }
 
 export function useCategory(id) {
   const category = useCategoryStore(state => state.categoryDetails[id])
   const setCategoryDetail = useCategoryStore(state => state.setCategoryDetail)
+  const removeCategory = useCategoryStore(state => state.removeCategory)
   const [loading, setLoading] = useState(false)
+
+  const refresh = useCallback(() => {
+    removeCategory(id)
+  }, [removeCategory, id])
 
   useEffect(() => {
     if (id && !category && !loading) {
@@ -43,5 +53,5 @@ export function useCategory(id) {
     }
   }, [id, category, loading, setCategoryDetail])
 
-  return { category, loading }
+  return { category, loading, refresh }
 }

--- a/hooks/use-categories.js
+++ b/hooks/use-categories.js
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useCategoryStore } from '@/app/store/use-category-store'
+
+export function useCategories() {
+  const categories = useCategoryStore(state => state.categories)
+  const setCategories = useCategoryStore(state => state.setCategories)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!categories && !loading) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/blogs/categories')
+        .then(res => res.json())
+        .then(json => {
+          if (Array.isArray(json?.data)) {
+            setCategories(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [categories, loading, setCategories])
+
+  return { categories, loading }
+}
+
+export function useCategory(id) {
+  const category = useCategoryStore(state => state.categoryDetails[id])
+  const setCategoryDetail = useCategoryStore(state => state.setCategoryDetail)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (id && !category && !loading) {
+      setLoading(true)
+      apiFetch(`/api/v1/admin/blogs/categories/${id}`)
+        .then(res => res.json())
+        .then(json => {
+          if (json?.data) {
+            setCategoryDetail(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [id, category, loading, setCategoryDetail])
+
+  return { category, loading }
+}


### PR DESCRIPTION
## Summary
- create loading states for admin category pages using shadcn skeletons
- persist fetched category data with zustand so navigating back is instant
- avoid API re-fetch if data already cached in zustand

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864cebdfd888328a1ce9a14a0712267