### PR TITLE
Enhance authors and categories loading behavior

### DIFF
--- a/app/admin/blogs/authors/[id]/edit/EditAuthorForm.jsx
+++ b/app/admin/blogs/authors/[id]/edit/EditAuthorForm.jsx
@@ -27,6 +27,8 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateAuthor } from "@/app/actions/authors";
 import { useEffect } from "react";
+import { useAuthor } from "@/hooks/use-authors";
+import { useAuthorStore } from "@/app/store/use-author-store";
 
 const authorFormSchema = z.object({
   author_name: z.string()
@@ -56,6 +58,8 @@ const authorFormSchema = z.object({
 
 export default function EditAuthorForm({ author }) {
   const router = useRouter();
+  useAuthor(author._id);
+  const updateAuth = useAuthorStore(state => state.updateAuthor);
   const form = useForm({
     resolver: zodResolver(authorFormSchema),
     defaultValues: {
@@ -105,9 +109,11 @@ export default function EditAuthorForm({ author }) {
       formData.append("status", String(data.status || 1));
       const result = await updateAuthor(author._id, formData);
       if (result.success) {
+        if (result.data) {
+          updateAuth(author._id, result.data);
+        }
         toast.success("Author updated successfully!");
         router.push(`/admin/blogs/authors/${author._id}`);
-        router.refresh();
       } else {
         toast.error(result.error || "Failed to update author");
       }

--- a/app/admin/blogs/authors/[id]/edit/loading.jsx
+++ b/app/admin/blogs/authors/[id]/edit/loading.jsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/[id]/edit/page.jsx
+++ b/app/admin/blogs/authors/[id]/edit/page.jsx
@@ -1,20 +1,24 @@
+"use client";
 import EditAuthorForm from "./EditAuthorForm";
+import { useAuthor } from "@/hooks/use-authors";
+import { use as usePromise } from "react";
+import AuthorEditSkeleton from "@/components/skeleton/author-edit-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/authors/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const author = json?.data;
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { author } = useAuthor(id);
 
-  if (!author) {
+  if (author === undefined) {
+    return <AuthorEditSkeleton />;
+  }
+
+  if (author === null) {
     return <div className="p-4">Author not found</div>;
   }
 
   return (
-    <>
-      <div className="w-full p-4">
-        <EditAuthorForm author={author} />
-      </div>
-    </>
+    <div className="w-full p-4">
+      <EditAuthorForm author={author} />
+    </div>
   );
 }

--- a/app/admin/blogs/authors/[id]/loading.jsx
+++ b/app/admin/blogs/authors/[id]/loading.jsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-6">
+            <Skeleton className="h-[120px] w-[120px] rounded-lg" />
+            <div className="flex-1 space-y-2 text-sm">
+              {[...Array(7)].map((_, i) => (
+                <Skeleton key={i} className="h-4 w-full" />
+              ))}
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/[id]/page.jsx
+++ b/app/admin/blogs/authors/[id]/page.jsx
@@ -1,65 +1,67 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import DeleteAuthorButtons from "@/components/delete-author-buttons";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import Link from "next/link";
+import { useAuthor } from "@/hooks/use-authors";
+import { use as usePromise } from "react";
+import AuthorDetailSkeleton from "@/components/skeleton/author-detail-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/authors/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const author = json?.data;
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { author } = useAuthor(id);
+  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
 
-  if (!author) {
-    return (
-      <div className="p-4">Author not found</div>
-    );
+  if (author === undefined) {
+    return <AuthorDetailSkeleton />;
   }
 
-  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
+  if (author === null) {
+    return <div className="p-4">Author not found</div>;
+  }
+
   const imageSrc = author.image?.startsWith('http')
     ? author.image
     : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/authors/${author.image}`;
 
   return (
-    <>
-      <div className="w-full p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Author Details</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col md:flex-row gap-6">
-              <Image src={imageSrc} alt={author.author_name} width={120} height={120} className="rounded-lg object-cover" />
-              <div className="space-y-2 text-sm">
-                <p><strong>Name:</strong> {author.author_name}</p>
-                <p><strong>Description:</strong> {author.description}</p>
-                {author.linkedin_link && (
-                  <p><strong>LinkedIn:</strong> <a href={author.linkedin_link} target="_blank" className="text-blue-600 underline">{author.linkedin_link}</a></p>
-                )}
-                {author.facebook_link && (
-                  <p><strong>Facebook:</strong> <a href={author.facebook_link} target="_blank" className="text-blue-600 underline">{author.facebook_link}</a></p>
-                )}
-                {author.twitter_link && (
-                  <p><strong>Twitter:</strong> <a href={author.twitter_link} target="_blank" className="text-blue-600 underline">{author.twitter_link}</a></p>
-                )}
-                <p><strong>Status:</strong> {statusMap[author.status]}</p>
-                <p><strong>Blogs:</strong> {author.blog_count}</p>
-                <p><strong>Created:</strong> {new Date(author.created_date).toLocaleString()}</p>
-                {author.deleted_at && (
-                  <p><strong>Deleted:</strong> {new Date(author.deleted_at).toLocaleString()}</p>
-                )}
-              </div>
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Author Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-6">
+            <Image src={imageSrc} alt={author.author_name} width={120} height={120} className="rounded-lg object-cover" />
+            <div className="space-y-2 text-sm">
+              <p><strong>Name:</strong> {author.author_name}</p>
+              <p><strong>Description:</strong> {author.description}</p>
+              {author.linkedin_link && (
+                <p><strong>LinkedIn:</strong> <a href={author.linkedin_link} target="_blank" className="text-blue-600 underline">{author.linkedin_link}</a></p>
+              )}
+              {author.facebook_link && (
+                <p><strong>Facebook:</strong> <a href={author.facebook_link} target="_blank" className="text-blue-600 underline">{author.facebook_link}</a></p>
+              )}
+              {author.twitter_link && (
+                <p><strong>Twitter:</strong> <a href={author.twitter_link} target="_blank" className="text-blue-600 underline">{author.twitter_link}</a></p>
+              )}
+              <p><strong>Status:</strong> {statusMap[author.status]}</p>
+              <p><strong>Blogs:</strong> {author.blog_count}</p>
+              <p><strong>Created:</strong> {new Date(author.created_date).toLocaleString()}</p>
+              {author.deleted_at && (
+                <p><strong>Deleted:</strong> {new Date(author.deleted_at).toLocaleString()}</p>
+              )}
             </div>
-            <div className="mt-4 flex gap-2 justify-end">
-              <Link href={`/admin/blogs/authors/${author._id}/edit`}>
-                <Button type="button">Edit</Button>
-              </Link>
-              <DeleteAuthorButtons id={author._id} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+          </div>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Link href={`/admin/blogs/authors/${author._id}/edit`}>
+              <Button type="button">Edit</Button>
+            </Link>
+            <DeleteAuthorButtons id={author._id} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/app/admin/blogs/authors/add/loading.jsx
+++ b/app/admin/blogs/authors/add/loading.jsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-3 w-40" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+              <Skeleton className="h-3 w-64" />
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/add/page.jsx
+++ b/app/admin/blogs/authors/add/page.jsx
@@ -24,7 +24,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
 import { createAuthor } from "@/app/actions/authors";
-import { useRouter } from "next/navigation";
+import { useAuthorStore } from "@/app/store/use-author-store";
 
 const authorFormSchema = z.object({
   author_name: z.string()
@@ -53,7 +53,6 @@ const authorFormSchema = z.object({
 });
 
 export default function Page() {
-  const router = useRouter();
   const form = useForm({
     resolver: zodResolver(authorFormSchema),
     defaultValues: {
@@ -64,6 +63,9 @@ export default function Page() {
       twitter_link: "",
     },
   });
+  const authors = useAuthorStore(state => state.authors);
+  const setAuthors = useAuthorStore(state => state.setAuthors);
+  const setAuthorDetail = useAuthorStore(state => state.setAuthorDetail);
   async function onSubmit(data) {
     try {
       const formData = new FormData();
@@ -86,10 +88,13 @@ export default function Page() {
       const result = await createAuthor(formData);
       
       if (result.success) {
+        if (result.data) {
+          const newAuthor = result.data;
+          setAuthorDetail(newAuthor._id || newAuthor.id, newAuthor);
+          setAuthors(authors ? [newAuthor, ...authors] : [newAuthor]);
+        }
         toast.success("Author created successfully!");
         form.reset();
-        router.push(`/admin/blogs/authors`);
-        router.refresh();
       } else {
         toast.error(result.error || "Failed to create author");
       }

--- a/app/admin/blogs/authors/loading.jsx
+++ b/app/admin/blogs/authors/loading.jsx
@@ -1,0 +1,42 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(7)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(7)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/page.jsx
+++ b/app/admin/blogs/authors/page.jsx
@@ -1,16 +1,16 @@
+"use client";
 import { AuthorTable } from "@/components/authorTable";
-import { cookies } from "next/headers";
-import { hasServerPermission } from "@/helpers/permissions";
+import AuthorTableSkeleton from "@/components/skeleton/author-table-skeleton";
+import { useAuthors } from "@/hooks/use-authors";
+import { usePermission } from "@/hooks/use-permission";
 
-export default async function Page() {
-  const store = await cookies();
-  const canAdd = hasServerPermission(store, 'authors', 'write');
-  const canEdit = hasServerPermission(store, 'authors', 'edit');
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/authors`, { cache: 'no-store' });
-  const json = await res.json();
-  const authors = Array.isArray(json?.data) ? json.data : [];
+export default function Page() {
+  const { authors } = useAuthors();
+  const canAdd = usePermission('authors', 'write');
+  const canEdit = usePermission('authors', 'edit');
+
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
-  const data = authors.map(author => ({
+  const data = authors ? authors.map(author => ({
     id: author._id,
     author_name: author.author_name,
     description: author.description,
@@ -22,17 +22,15 @@ export default async function Page() {
     created_date: author.created_date,
     modified_date: author.modified_date,
     blog_count: author.blog_count || 0,
-  }));
+  })) : [];
+
+  if (!authors) {
+    return <AuthorTableSkeleton />;
+  }
 
   return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        {/* <div className="space-y-1">
-          <h2 className="text-3xl font-bold tracking-tight">Authors</h2>
-          <p className="text-muted-foreground">Authors are the people who have contributed to the blogs.</p>
-        </div> */}
-        <AuthorTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <AuthorTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
   );
 }

--- a/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
+++ b/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
@@ -24,6 +24,8 @@ import {
 } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateCategory } from "@/app/actions/categories";
+import { useCategory } from "@/hooks/use-categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -37,6 +39,8 @@ const categoryFormSchema = z.object({
 
 export default function EditCategoryForm({ category }) {
   const router = useRouter();
+  useCategory(category._id); // ensure detail cached
+  const updateCat = useCategoryStore(state => state.updateCategory);
   const form = useForm({
     resolver: zodResolver(categoryFormSchema),
     defaultValues: {
@@ -54,9 +58,11 @@ export default function EditCategoryForm({ category }) {
       formData.append("status", String(data.status || 1));
       const result = await updateCategory(category._id, formData);
       if (result.success) {
+        if (result.data) {
+          updateCat(category._id, result.data);
+        }
         toast.success("Category updated successfully!");
         router.push(`/admin/blogs/categories/${category._id}`);
-        router.refresh();
       } else {
         toast.error(result.error || "Failed to update category");
       }

--- a/app/admin/blogs/categories/[id]/edit/loading.jsx
+++ b/app/admin/blogs/categories/[id]/edit/loading.jsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/edit/page.jsx
+++ b/app/admin/blogs/categories/[id]/edit/page.jsx
@@ -1,20 +1,24 @@
+"use client";
 import EditCategoryForm from "./EditCategoryForm";
+import { useCategory } from "@/hooks/use-categories";
+import { use as usePromise } from "react";
+import CategoryEditSkeleton from "@/components/skeleton/category-edit-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const category = json?.data;
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { category } = useCategory(id);
 
-  if (!category) {
+  if (category === undefined) {
+    return <CategoryEditSkeleton />;
+  }
+
+  if (category === null) {
     return <div className="p-4">Category not found</div>;
   }
 
   return (
-    <>
-      <div className="w-full p-4">
-        <EditCategoryForm category={category} />
-      </div>
-    </>
+    <div className="w-full p-4">
+      <EditCategoryForm category={category} />
+    </div>
   );
 }

--- a/app/admin/blogs/categories/[id]/loading.jsx
+++ b/app/admin/blogs/categories/[id]/loading.jsx
@@ -1,0 +1,27 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/page.jsx
+++ b/app/admin/blogs/categories/[id]/page.jsx
@@ -1,49 +1,50 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import DeleteCategoryButtons from "@/components/delete-category-buttons";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { useCategory } from "@/hooks/use-categories";
+import { use as usePromise } from "react";
+import CategoryDetailSkeleton from "@/components/skeleton/category-detail-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const category = json?.data;
-
-  if (!category) {
-    return (
-      <div className="p-4">Category not found</div>
-    );
-  }
-
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { category } = useCategory(id);
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
 
+  if (category === undefined) {
+    return <CategoryDetailSkeleton />;
+  }
+
+  if (category === null) {
+    return <div className="p-4">Category not found</div>;
+  }
+
   return (
-    <>
-      <div className="w-full p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Category Details</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2 text-sm">
-              <p><strong>Name:</strong> {category.category_name}</p>
-              <p><strong>Description:</strong> {category.description}</p>
-              <p><strong>Status:</strong> {statusMap[category.status]}</p>
-              <p><strong>Blogs:</strong> {category.blog_count}</p>
-              <p><strong>Created:</strong> {new Date(category.created_date).toLocaleString()}</p>
-              {category.deleted_at && (
-                <p><strong>Deleted:</strong> {new Date(category.deleted_at).toLocaleString()}</p>
-              )}
-            </div>
-            <div className="mt-4 flex gap-2 justify-end">
-              <Link href={`/admin/blogs/categories/${category._id}/edit`}>
-                <Button type="button">Edit</Button>
-              </Link>
-              <DeleteCategoryButtons id={category._id} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Category Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            <p><strong>Name:</strong> {category.category_name}</p>
+            <p><strong>Description:</strong> {category.description}</p>
+            <p><strong>Status:</strong> {statusMap[category.status]}</p>
+            <p><strong>Blogs:</strong> {category.blog_count}</p>
+            <p><strong>Created:</strong> {new Date(category.created_date).toLocaleString()}</p>
+            {category.deleted_at && (
+              <p><strong>Deleted:</strong> {new Date(category.deleted_at).toLocaleString()}</p>
+            )}
+          </div>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Link href={`/admin/blogs/categories/${category._id}/edit`}>
+              <Button type="button">Edit</Button>
+            </Link>
+            <DeleteCategoryButtons id={category._id} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/app/admin/blogs/categories/add/loading.jsx
+++ b/app/admin/blogs/categories/add/loading.jsx
@@ -1,0 +1,36 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-3 w-40" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+              <Skeleton className="h-3 w-64" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/add/page.jsx
+++ b/app/admin/blogs/categories/add/page.jsx
@@ -23,6 +23,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
 import { createCategory } from "@/app/actions/categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -41,6 +42,9 @@ export default function Page() {
       description: "",
     },
   });
+  const categories = useCategoryStore((state) => state.categories);
+  const setCategories = useCategoryStore((state) => state.setCategories);
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
   async function onSubmit(data) {
     try {
       const formData = new FormData();
@@ -48,6 +52,11 @@ export default function Page() {
       formData.append('description', data.description.trim());
       const result = await createCategory(formData);
       if (result.success) {
+        if (result.data) {
+          const newCategory = result.data;
+          setCategoryDetail(newCategory._id || newCategory.id, newCategory);
+          setCategories(categories ? [newCategory, ...categories] : [newCategory]);
+        }
         toast.success("Category created successfully!");
         form.reset();
       } else {

--- a/app/admin/blogs/categories/loading.jsx
+++ b/app/admin/blogs/categories/loading.jsx
@@ -1,0 +1,42 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(6)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(6)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/page.jsx
+++ b/app/admin/blogs/categories/page.jsx
@@ -1,16 +1,16 @@
+"use client";
 import { CategoryTable } from "@/components/categoryTable";
-import { cookies } from "next/headers";
-import { hasServerPermission } from "@/helpers/permissions";
+import CategoryTableSkeleton from "@/components/skeleton/category-table-skeleton";
+import { useCategories } from "@/hooks/use-categories";
+import { usePermission } from "@/hooks/use-permission";
 
-export default async function Page() {
-  const store = await cookies();
-  const canAdd = hasServerPermission(store, 'categories', 'write');
-  const canEdit = hasServerPermission(store, 'categories', 'edit');
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories`, { cache: 'no-store' });
-  const json = await res.json();
-  const categories = Array.isArray(json?.data) ? json.data : [];
+export default function Page() {
+  const { categories } = useCategories();
+  const canAdd = usePermission('categories', 'write');
+  const canEdit = usePermission('categories', 'edit');
+
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
-  const data = categories.map(cat => ({
+  const data = categories ? categories.map(cat => ({
     id: cat._id,
     category_name: cat.category_name,
     description: cat.description,
@@ -18,13 +18,15 @@ export default async function Page() {
     created_date: cat.created_date,
     modified_date: cat.modified_date,
     blog_count: cat.blog_count,
-  }));
+  })) : [];
+
+  if (!categories) {
+    return <CategoryTableSkeleton />;
+  }
 
   return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
   );
 }

--- a/app/api/v1/admin/admins/me/route.js
+++ b/app/api/v1/admin/admins/me/route.js
@@ -7,7 +7,7 @@ import Admin from '@/app/models/Admin';
 export async function GET(req) {
   let token = extractToken(req.headers);
   if (!token) {
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     token = cookieStore.get('token')?.value || null;
   }
   if (!token) {

--- a/app/api/v1/admin/departments/[id]/route.js
+++ b/app/api/v1/admin/departments/[id]/route.js
@@ -6,10 +6,11 @@ import { ensurePermission } from '@/lib/rbac';
 import { syncAdminsFromDB } from '@/app/lib/adminsFile';
 
 export async function GET(req, { params }) {
+  const { id } = await params;
   const admin = await ensurePermission(req, 'departments', 'read');
   if (!admin) return NextResponse.json({ success: false, error: 'Permission denied' }, { status: 403 });
   await connectDB();
-  const dept = await Department.findById(params.id).lean();
+  const dept = await Department.findById(id).lean();
   if (!dept) return NextResponse.json({ success: false, error: 'Department not found' }, { status: 404 });
   return NextResponse.json({ success: true, data: dept });
 }

--- a/app/store/use-author-store.js
+++ b/app/store/use-author-store.js
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+
+export const useAuthorStore = create((set) => ({
+  authors: null,
+  authorDetails: {},
+  setAuthors: (authors) => set({ authors }),
+  setAuthorDetail: (id, author) =>
+    set((state) => ({
+      authorDetails: { ...state.authorDetails, [id]: author },
+    })),
+  updateAuthor: (id, updates) =>
+    set((state) => {
+      const authors = state.authors
+        ? state.authors.map((a) =>
+            (a._id || a.id) === id ? { ...a, ...updates } : a
+          )
+        : null
+      const detail = state.authorDetails[id]
+      return {
+        authors,
+        authorDetails: detail
+          ? { ...state.authorDetails, [id]: { ...detail, ...updates } }
+          : state.authorDetails,
+      }
+    }),
+  clearAuthors: () => set({ authors: null }),
+  removeAuthor: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.authorDetails
+      return { authorDetails: rest }
+    }),
+}))

--- a/app/store/use-category-store.js
+++ b/app/store/use-category-store.js
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+
+export const useCategoryStore = create((set) => ({
+  categories: null,
+  categoryDetails: {},
+  setCategories: (cats) => set({ categories: cats }),
+  setCategoryDetail: (id, cat) =>
+    set((state) => ({
+      categoryDetails: { ...state.categoryDetails, [id]: cat },
+    })),
+  updateCategory: (id, updates) =>
+    set((state) => {
+      const categories = state.categories
+        ? state.categories.map((c) =>
+            (c._id || c.id) === id ? { ...c, ...updates } : c
+          )
+        : null;
+      const detail = state.categoryDetails[id];
+      return {
+        categories,
+        categoryDetails: detail
+          ? { ...state.categoryDetails, [id]: { ...detail, ...updates } }
+          : state.categoryDetails,
+      };
+    }),
+  clearCategories: () => set({ categories: null }),
+  removeCategory: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.categoryDetails
+      return { categoryDetails: rest }
+    }),
+}))

--- a/components/authorTable.jsx
+++ b/components/authorTable.jsx
@@ -38,12 +38,12 @@ import { Badge } from "@/components/ui/badge"
 import Image from "next/image"
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import apiFetch from "@/helpers/apiFetch"
+import { useAuthorStore } from "@/app/store/use-author-store"
 
 function AuthorActions({ author, canEdit }) {
-  const router = useRouter()
+  const updateAuthor = useAuthorStore(state => state.updateAuthor)
 
   const handleStatusChange = async (status) => {
     try {
@@ -56,7 +56,7 @@ function AuthorActions({ author, canEdit }) {
       const data = await res.json()
       if (data.success) {
         toast.success('Status updated')
-        router.refresh()
+        updateAuthor(author.id, { status })
       } else {
         toast.error(data.error || 'Failed to update status')
       }

--- a/components/category-store-initializer.jsx
+++ b/components/category-store-initializer.jsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect } from "react";
+import { useCategoryStore } from "@/app/store/use-category-store";
+
+export default function CategoryStoreInitializer({ categories, category }) {
+  const setCategories = useCategoryStore((state) => state.setCategories);
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
+
+  useEffect(() => {
+    if (categories) {
+      setCategories(categories);
+    }
+  }, [categories, setCategories]);
+
+  useEffect(() => {
+    if (category) {
+      setCategoryDetail(category._id || category.id, category);
+    }
+  }, [category, setCategoryDetail]);
+
+  return null;
+}

--- a/components/categoryTable.jsx
+++ b/components/categoryTable.jsx
@@ -35,12 +35,12 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 function CategoryActions({ category, canEdit }) {
-  const router = useRouter();
+  const updateCategory = useCategoryStore(state => state.updateCategory);
 
   const handleStatusChange = async (status) => {
     try {
@@ -53,7 +53,7 @@ function CategoryActions({ category, canEdit }) {
       const data = await res.json();
       if (data.success) {
         toast.success('Status updated');
-        router.refresh();
+        updateCategory(category.id, { status });
       } else {
         toast.error(data.error || 'Failed to update status');
       }

--- a/components/delete-author-buttons.jsx
+++ b/components/delete-author-buttons.jsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useAuthor } from "@/hooks/use-authors";
+import { useAuthorStore } from "@/app/store/use-author-store";
 import { Copy } from "lucide-react";
 import Link from "next/link";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -14,6 +16,8 @@ export default function DeleteAuthorButtons({ id }) {
   const [open, setOpen] = useState(false);
   const [blogs, setBlogs] = useState(null);
   const [loading, setLoading] = useState(false);
+  useAuthor(id); // preload for cache update
+  const removeAuthor = useAuthorStore(state => state.removeAuthor);
 
   const handleOpen = async () => {
     setOpen(true);
@@ -33,6 +37,7 @@ export default function DeleteAuthorButtons({ id }) {
       });
       const data = await res.json();
       if (data.success) {
+        removeAuthor(id);
         toast.success(data.message || "Author deleted");
         router.push("/admin/blogs/authors");
       } else {

--- a/components/delete-category-buttons.jsx
+++ b/components/delete-category-buttons.jsx
@@ -5,6 +5,8 @@ import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, Dialo
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useCategory } from "@/hooks/use-categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 import { Copy } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
@@ -14,6 +16,8 @@ export default function DeleteCategoryButtons({ id }) {
   const [open, setOpen] = useState(false);
   const [blogs, setBlogs] = useState(null);
   const [loading, setLoading] = useState(false);
+  useCategory(id); // preload for cache update
+  const removeCategory = useCategoryStore(state => state.removeCategory);
 
   const handleOpen = async () => {
     setOpen(true);
@@ -33,6 +37,7 @@ export default function DeleteCategoryButtons({ id }) {
       });
       const data = await res.json();
       if (data.success) {
+        removeCategory(id);
         toast.success(data.message || "Category deleted");
         router.push("/admin/blogs/categories");
       } else {

--- a/components/skeleton/author-detail-skeleton.jsx
+++ b/components/skeleton/author-detail-skeleton.jsx
@@ -1,0 +1,31 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AuthorDetailSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-6">
+            <Skeleton className="h-[120px] w-[120px] rounded-lg" />
+            <div className="flex-1 space-y-2 text-sm">
+              {[...Array(7)].map((_, i) => (
+                <Skeleton key={i} className="h-4 w-full" />
+              ))}
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/author-edit-skeleton.jsx
+++ b/components/skeleton/author-edit-skeleton.jsx
@@ -1,0 +1,47 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AuthorEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/author-table-skeleton.jsx
+++ b/components/skeleton/author-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function AuthorTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(7)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(7)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/category-detail-skeleton.jsx
+++ b/components/skeleton/category-detail-skeleton.jsx
@@ -1,0 +1,28 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function CategoryDetailSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/category-edit-skeleton.jsx
+++ b/components/skeleton/category-edit-skeleton.jsx
@@ -1,0 +1,39 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function CategoryEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/category-table-skeleton.jsx
+++ b/components/skeleton/category-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function CategoryTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(6)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(6)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/hooks/use-authors.js
+++ b/hooks/use-authors.js
@@ -1,0 +1,55 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useAuthorStore } from '@/app/store/use-author-store'
+
+export function useAuthors() {
+  const authors = useAuthorStore((state) => state.authors)
+  const setAuthors = useAuthorStore((state) => state.setAuthors)
+  const clearAuthors = useAuthorStore((state) => state.clearAuthors)
+  const [loading, setLoading] = useState(!authors)
+
+  const refresh = useCallback(() => {
+    clearAuthors()
+  }, [clearAuthors])
+
+  useEffect(() => {
+    if (!authors) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/blogs/authors')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setAuthors(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [authors, setAuthors])
+
+  return { authors, loading, refresh }
+}
+
+export function useAuthor(id) {
+  const author = useAuthorStore((state) => state.authorDetails[id])
+  const setAuthorDetail = useAuthorStore((state) => state.setAuthorDetail)
+  const removeAuthor = useAuthorStore((state) => state.removeAuthor)
+  const [loading, setLoading] = useState(!author && !!id)
+
+  const refresh = useCallback(() => {
+    removeAuthor(id)
+  }, [removeAuthor, id])
+
+  useEffect(() => {
+    if (id && !author) {
+      setLoading(true)
+      apiFetch(`/api/v1/admin/blogs/authors/${id}`)
+        .then((res) => res.json())
+        .then((json) => {
+          setAuthorDetail(id, json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [id, author, setAuthorDetail])
+
+  return { author, loading, refresh }
+}

--- a/hooks/use-categories.js
+++ b/hooks/use-categories.js
@@ -1,0 +1,55 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useCategoryStore } from '@/app/store/use-category-store'
+
+export function useCategories() {
+  const categories = useCategoryStore((state) => state.categories)
+  const setCategories = useCategoryStore((state) => state.setCategories)
+  const clearCategories = useCategoryStore((state) => state.clearCategories)
+  const [loading, setLoading] = useState(!categories)
+
+  const refresh = useCallback(() => {
+    clearCategories()
+  }, [clearCategories])
+
+  useEffect(() => {
+    if (!categories) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/blogs/categories')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setCategories(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [categories, setCategories])
+
+  return { categories, loading, refresh }
+}
+
+export function useCategory(id) {
+  const category = useCategoryStore((state) => state.categoryDetails[id])
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail)
+  const removeCategory = useCategoryStore((state) => state.removeCategory)
+  const [loading, setLoading] = useState(!category && !!id)
+
+  const refresh = useCallback(() => {
+    removeCategory(id)
+  }, [removeCategory, id])
+
+  useEffect(() => {
+    if (id && !category) {
+      setLoading(true)
+      apiFetch(`/api/v1/admin/blogs/categories/${id}`)
+        .then((res) => res.json())
+        .then((json) => {
+          setCategoryDetail(id, json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [id, category, setCategoryDetail])
+
+  return { category, loading, refresh }
+}


### PR DESCRIPTION
## Summary
- adjust Zustand stores to accept id when setting details
- refresh hooks to start in loading state and set detail null if not found
- remove flicker by showing skeletons until data is loaded
- update add forms and initializer for new store APIs

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864cebdfd888328a1ce9a14a0712267