### PR TITLE
Enhance leads and newsletter modules with caching

### DIFF
--- a/app/admin/blogs/authors/[id]/edit/EditAuthorForm.jsx
+++ b/app/admin/blogs/authors/[id]/edit/EditAuthorForm.jsx
@@ -27,6 +27,8 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateAuthor } from "@/app/actions/authors";
 import { useEffect } from "react";
+import { useAuthor } from "@/hooks/use-authors";
+import { useAuthorStore } from "@/app/store/use-author-store";
 
 const authorFormSchema = z.object({
   author_name: z.string()
@@ -56,6 +58,8 @@ const authorFormSchema = z.object({
 
 export default function EditAuthorForm({ author }) {
   const router = useRouter();
+  useAuthor(author._id);
+  const updateAuth = useAuthorStore(state => state.updateAuthor);
   const form = useForm({
     resolver: zodResolver(authorFormSchema),
     defaultValues: {
@@ -105,9 +109,11 @@ export default function EditAuthorForm({ author }) {
       formData.append("status", String(data.status || 1));
       const result = await updateAuthor(author._id, formData);
       if (result.success) {
+        if (result.data) {
+          updateAuth(author._id, result.data);
+        }
         toast.success("Author updated successfully!");
         router.push(`/admin/blogs/authors/${author._id}`);
-        router.refresh();
       } else {
         toast.error(result.error || "Failed to update author");
       }

--- a/app/admin/blogs/authors/[id]/edit/loading.jsx
+++ b/app/admin/blogs/authors/[id]/edit/loading.jsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/[id]/edit/page.jsx
+++ b/app/admin/blogs/authors/[id]/edit/page.jsx
@@ -1,20 +1,24 @@
+"use client";
 import EditAuthorForm from "./EditAuthorForm";
+import { useAuthor } from "@/hooks/use-authors";
+import { use as usePromise } from "react";
+import AuthorEditSkeleton from "@/components/skeleton/author-edit-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/authors/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const author = json?.data;
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { author } = useAuthor(id);
 
-  if (!author) {
+  if (author === undefined) {
+    return <AuthorEditSkeleton />;
+  }
+
+  if (author === null) {
     return <div className="p-4">Author not found</div>;
   }
 
   return (
-    <>
-      <div className="w-full p-4">
-        <EditAuthorForm author={author} />
-      </div>
-    </>
+    <div className="w-full p-4">
+      <EditAuthorForm author={author} />
+    </div>
   );
 }

--- a/app/admin/blogs/authors/[id]/loading.jsx
+++ b/app/admin/blogs/authors/[id]/loading.jsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-6">
+            <Skeleton className="h-[120px] w-[120px] rounded-lg" />
+            <div className="flex-1 space-y-2 text-sm">
+              {[...Array(7)].map((_, i) => (
+                <Skeleton key={i} className="h-4 w-full" />
+              ))}
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/[id]/page.jsx
+++ b/app/admin/blogs/authors/[id]/page.jsx
@@ -1,65 +1,67 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import DeleteAuthorButtons from "@/components/delete-author-buttons";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import Link from "next/link";
+import { useAuthor } from "@/hooks/use-authors";
+import { use as usePromise } from "react";
+import AuthorDetailSkeleton from "@/components/skeleton/author-detail-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/authors/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const author = json?.data;
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { author } = useAuthor(id);
+  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
 
-  if (!author) {
-    return (
-      <div className="p-4">Author not found</div>
-    );
+  if (author === undefined) {
+    return <AuthorDetailSkeleton />;
   }
 
-  const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
+  if (author === null) {
+    return <div className="p-4">Author not found</div>;
+  }
+
   const imageSrc = author.image?.startsWith('http')
     ? author.image
     : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/authors/${author.image}`;
 
   return (
-    <>
-      <div className="w-full p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Author Details</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col md:flex-row gap-6">
-              <Image src={imageSrc} alt={author.author_name} width={120} height={120} className="rounded-lg object-cover" />
-              <div className="space-y-2 text-sm">
-                <p><strong>Name:</strong> {author.author_name}</p>
-                <p><strong>Description:</strong> {author.description}</p>
-                {author.linkedin_link && (
-                  <p><strong>LinkedIn:</strong> <a href={author.linkedin_link} target="_blank" className="text-blue-600 underline">{author.linkedin_link}</a></p>
-                )}
-                {author.facebook_link && (
-                  <p><strong>Facebook:</strong> <a href={author.facebook_link} target="_blank" className="text-blue-600 underline">{author.facebook_link}</a></p>
-                )}
-                {author.twitter_link && (
-                  <p><strong>Twitter:</strong> <a href={author.twitter_link} target="_blank" className="text-blue-600 underline">{author.twitter_link}</a></p>
-                )}
-                <p><strong>Status:</strong> {statusMap[author.status]}</p>
-                <p><strong>Blogs:</strong> {author.blog_count}</p>
-                <p><strong>Created:</strong> {new Date(author.created_date).toLocaleString()}</p>
-                {author.deleted_at && (
-                  <p><strong>Deleted:</strong> {new Date(author.deleted_at).toLocaleString()}</p>
-                )}
-              </div>
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Author Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-6">
+            <Image src={imageSrc} alt={author.author_name} width={120} height={120} className="rounded-lg object-cover" />
+            <div className="space-y-2 text-sm">
+              <p><strong>Name:</strong> {author.author_name}</p>
+              <p><strong>Description:</strong> {author.description}</p>
+              {author.linkedin_link && (
+                <p><strong>LinkedIn:</strong> <a href={author.linkedin_link} target="_blank" className="text-blue-600 underline">{author.linkedin_link}</a></p>
+              )}
+              {author.facebook_link && (
+                <p><strong>Facebook:</strong> <a href={author.facebook_link} target="_blank" className="text-blue-600 underline">{author.facebook_link}</a></p>
+              )}
+              {author.twitter_link && (
+                <p><strong>Twitter:</strong> <a href={author.twitter_link} target="_blank" className="text-blue-600 underline">{author.twitter_link}</a></p>
+              )}
+              <p><strong>Status:</strong> {statusMap[author.status]}</p>
+              <p><strong>Blogs:</strong> {author.blog_count}</p>
+              <p><strong>Created:</strong> {new Date(author.created_date).toLocaleString()}</p>
+              {author.deleted_at && (
+                <p><strong>Deleted:</strong> {new Date(author.deleted_at).toLocaleString()}</p>
+              )}
             </div>
-            <div className="mt-4 flex gap-2 justify-end">
-              <Link href={`/admin/blogs/authors/${author._id}/edit`}>
-                <Button type="button">Edit</Button>
-              </Link>
-              <DeleteAuthorButtons id={author._id} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+          </div>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Link href={`/admin/blogs/authors/${author._id}/edit`}>
+              <Button type="button">Edit</Button>
+            </Link>
+            <DeleteAuthorButtons id={author._id} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/app/admin/blogs/authors/add/loading.jsx
+++ b/app/admin/blogs/authors/add/loading.jsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-3 w-40" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+              <Skeleton className="h-3 w-64" />
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/add/page.jsx
+++ b/app/admin/blogs/authors/add/page.jsx
@@ -24,7 +24,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
 import { createAuthor } from "@/app/actions/authors";
-import { useRouter } from "next/navigation";
+import { useAuthorStore } from "@/app/store/use-author-store";
 
 const authorFormSchema = z.object({
   author_name: z.string()
@@ -53,7 +53,6 @@ const authorFormSchema = z.object({
 });
 
 export default function Page() {
-  const router = useRouter();
   const form = useForm({
     resolver: zodResolver(authorFormSchema),
     defaultValues: {
@@ -64,6 +63,9 @@ export default function Page() {
       twitter_link: "",
     },
   });
+  const authors = useAuthorStore(state => state.authors);
+  const setAuthors = useAuthorStore(state => state.setAuthors);
+  const setAuthorDetail = useAuthorStore(state => state.setAuthorDetail);
   async function onSubmit(data) {
     try {
       const formData = new FormData();
@@ -86,10 +88,13 @@ export default function Page() {
       const result = await createAuthor(formData);
       
       if (result.success) {
+        if (result.data) {
+          const newAuthor = result.data;
+          setAuthorDetail(newAuthor._id || newAuthor.id, newAuthor);
+          setAuthors(authors ? [newAuthor, ...authors] : [newAuthor]);
+        }
         toast.success("Author created successfully!");
         form.reset();
-        router.push(`/admin/blogs/authors`);
-        router.refresh();
       } else {
         toast.error(result.error || "Failed to create author");
       }

--- a/app/admin/blogs/authors/loading.jsx
+++ b/app/admin/blogs/authors/loading.jsx
@@ -1,0 +1,42 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(7)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(7)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/blogs/authors/page.jsx
+++ b/app/admin/blogs/authors/page.jsx
@@ -1,16 +1,16 @@
+"use client";
 import { AuthorTable } from "@/components/authorTable";
-import { cookies } from "next/headers";
-import { hasServerPermission } from "@/helpers/permissions";
+import AuthorTableSkeleton from "@/components/skeleton/author-table-skeleton";
+import { useAuthors } from "@/hooks/use-authors";
+import { usePermission } from "@/hooks/use-permission";
 
-export default async function Page() {
-  const store = await cookies();
-  const canAdd = hasServerPermission(store, 'authors', 'write');
-  const canEdit = hasServerPermission(store, 'authors', 'edit');
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/authors`, { cache: 'no-store' });
-  const json = await res.json();
-  const authors = Array.isArray(json?.data) ? json.data : [];
+export default function Page() {
+  const { authors } = useAuthors();
+  const canAdd = usePermission('authors', 'write');
+  const canEdit = usePermission('authors', 'edit');
+
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
-  const data = authors.map(author => ({
+  const data = authors ? authors.map(author => ({
     id: author._id,
     author_name: author.author_name,
     description: author.description,
@@ -22,17 +22,15 @@ export default async function Page() {
     created_date: author.created_date,
     modified_date: author.modified_date,
     blog_count: author.blog_count || 0,
-  }));
+  })) : [];
+
+  if (!authors) {
+    return <AuthorTableSkeleton />;
+  }
 
   return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        {/* <div className="space-y-1">
-          <h2 className="text-3xl font-bold tracking-tight">Authors</h2>
-          <p className="text-muted-foreground">Authors are the people who have contributed to the blogs.</p>
-        </div> */}
-        <AuthorTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <AuthorTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
   );
 }

--- a/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
+++ b/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
@@ -24,6 +24,8 @@ import {
 } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { updateCategory } from "@/app/actions/categories";
+import { useCategory } from "@/hooks/use-categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -37,6 +39,8 @@ const categoryFormSchema = z.object({
 
 export default function EditCategoryForm({ category }) {
   const router = useRouter();
+  useCategory(category._id); // ensure detail cached
+  const updateCat = useCategoryStore(state => state.updateCategory);
   const form = useForm({
     resolver: zodResolver(categoryFormSchema),
     defaultValues: {
@@ -54,9 +58,11 @@ export default function EditCategoryForm({ category }) {
       formData.append("status", String(data.status || 1));
       const result = await updateCategory(category._id, formData);
       if (result.success) {
+        if (result.data) {
+          updateCat(category._id, result.data);
+        }
         toast.success("Category updated successfully!");
         router.push(`/admin/blogs/categories/${category._id}`);
-        router.refresh();
       } else {
         toast.error(result.error || "Failed to update category");
       }

--- a/app/admin/blogs/categories/[id]/edit/loading.jsx
+++ b/app/admin/blogs/categories/[id]/edit/loading.jsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/edit/page.jsx
+++ b/app/admin/blogs/categories/[id]/edit/page.jsx
@@ -1,20 +1,24 @@
+"use client";
 import EditCategoryForm from "./EditCategoryForm";
+import { useCategory } from "@/hooks/use-categories";
+import { use as usePromise } from "react";
+import CategoryEditSkeleton from "@/components/skeleton/category-edit-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const category = json?.data;
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { category } = useCategory(id);
 
-  if (!category) {
+  if (category === undefined) {
+    return <CategoryEditSkeleton />;
+  }
+
+  if (category === null) {
     return <div className="p-4">Category not found</div>;
   }
 
   return (
-    <>
-      <div className="w-full p-4">
-        <EditCategoryForm category={category} />
-      </div>
-    </>
+    <div className="w-full p-4">
+      <EditCategoryForm category={category} />
+    </div>
   );
 }

--- a/app/admin/blogs/categories/[id]/loading.jsx
+++ b/app/admin/blogs/categories/[id]/loading.jsx
@@ -1,0 +1,27 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/[id]/page.jsx
+++ b/app/admin/blogs/categories/[id]/page.jsx
@@ -1,49 +1,50 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import DeleteCategoryButtons from "@/components/delete-category-buttons";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { useCategory } from "@/hooks/use-categories";
+import { use as usePromise } from "react";
+import CategoryDetailSkeleton from "@/components/skeleton/category-detail-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const category = json?.data;
-
-  if (!category) {
-    return (
-      <div className="p-4">Category not found</div>
-    );
-  }
-
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { category } = useCategory(id);
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
 
+  if (category === undefined) {
+    return <CategoryDetailSkeleton />;
+  }
+
+  if (category === null) {
+    return <div className="p-4">Category not found</div>;
+  }
+
   return (
-    <>
-      <div className="w-full p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Category Details</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2 text-sm">
-              <p><strong>Name:</strong> {category.category_name}</p>
-              <p><strong>Description:</strong> {category.description}</p>
-              <p><strong>Status:</strong> {statusMap[category.status]}</p>
-              <p><strong>Blogs:</strong> {category.blog_count}</p>
-              <p><strong>Created:</strong> {new Date(category.created_date).toLocaleString()}</p>
-              {category.deleted_at && (
-                <p><strong>Deleted:</strong> {new Date(category.deleted_at).toLocaleString()}</p>
-              )}
-            </div>
-            <div className="mt-4 flex gap-2 justify-end">
-              <Link href={`/admin/blogs/categories/${category._id}/edit`}>
-                <Button type="button">Edit</Button>
-              </Link>
-              <DeleteCategoryButtons id={category._id} />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Category Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            <p><strong>Name:</strong> {category.category_name}</p>
+            <p><strong>Description:</strong> {category.description}</p>
+            <p><strong>Status:</strong> {statusMap[category.status]}</p>
+            <p><strong>Blogs:</strong> {category.blog_count}</p>
+            <p><strong>Created:</strong> {new Date(category.created_date).toLocaleString()}</p>
+            {category.deleted_at && (
+              <p><strong>Deleted:</strong> {new Date(category.deleted_at).toLocaleString()}</p>
+            )}
+          </div>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Link href={`/admin/blogs/categories/${category._id}/edit`}>
+              <Button type="button">Edit</Button>
+            </Link>
+            <DeleteCategoryButtons id={category._id} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/app/admin/blogs/categories/add/loading.jsx
+++ b/app/admin/blogs/categories/add/loading.jsx
@@ -1,0 +1,36 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-3 w-40" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+              <Skeleton className="h-3 w-64" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/add/page.jsx
+++ b/app/admin/blogs/categories/add/page.jsx
@@ -23,6 +23,7 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "sonner";
 import { createCategory } from "@/app/actions/categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 const categoryFormSchema = z.object({
   category_name: z.string()
@@ -41,6 +42,9 @@ export default function Page() {
       description: "",
     },
   });
+  const categories = useCategoryStore((state) => state.categories);
+  const setCategories = useCategoryStore((state) => state.setCategories);
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
   async function onSubmit(data) {
     try {
       const formData = new FormData();
@@ -48,6 +52,11 @@ export default function Page() {
       formData.append('description', data.description.trim());
       const result = await createCategory(formData);
       if (result.success) {
+        if (result.data) {
+          const newCategory = result.data;
+          setCategoryDetail(newCategory._id || newCategory.id, newCategory);
+          setCategories(categories ? [newCategory, ...categories] : [newCategory]);
+        }
         toast.success("Category created successfully!");
         form.reset();
       } else {

--- a/app/admin/blogs/categories/loading.jsx
+++ b/app/admin/blogs/categories/loading.jsx
@@ -1,0 +1,42 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(6)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(6)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/blogs/categories/page.jsx
+++ b/app/admin/blogs/categories/page.jsx
@@ -1,16 +1,16 @@
+"use client";
 import { CategoryTable } from "@/components/categoryTable";
-import { cookies } from "next/headers";
-import { hasServerPermission } from "@/helpers/permissions";
+import CategoryTableSkeleton from "@/components/skeleton/category-table-skeleton";
+import { useCategories } from "@/hooks/use-categories";
+import { usePermission } from "@/hooks/use-permission";
 
-export default async function Page() {
-  const store = await cookies();
-  const canAdd = hasServerPermission(store, 'categories', 'write');
-  const canEdit = hasServerPermission(store, 'categories', 'edit');
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/blogs/categories`, { cache: 'no-store' });
-  const json = await res.json();
-  const categories = Array.isArray(json?.data) ? json.data : [];
+export default function Page() {
+  const { categories } = useCategories();
+  const canAdd = usePermission('categories', 'write');
+  const canEdit = usePermission('categories', 'edit');
+
   const statusMap = { 1: 'active', 2: 'inactive', 3: 'suspended' };
-  const data = categories.map(cat => ({
+  const data = categories ? categories.map(cat => ({
     id: cat._id,
     category_name: cat.category_name,
     description: cat.description,
@@ -18,13 +18,15 @@ export default async function Page() {
     created_date: cat.created_date,
     modified_date: cat.modified_date,
     blog_count: cat.blog_count,
-  }));
+  })) : [];
+
+  if (!categories) {
+    return <CategoryTableSkeleton />;
+  }
 
   return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <CategoryTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
   );
 }

--- a/app/admin/blogs/images/[id]/edit/EditImageForm.jsx
+++ b/app/admin/blogs/images/[id]/edit/EditImageForm.jsx
@@ -1,0 +1,106 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import ImageCropperInput from "@/components/image-cropper-input";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import apiFetch from "@/helpers/apiFetch";
+import { useImageStore } from "@/app/store/use-image-store";
+import React from "react";
+
+const imageFormSchema = z.object({
+  image: z.any().refine((file) => !file || file.length === 1, "Only one image allowed"),
+});
+
+export default function EditImageForm({ image }) {
+  const router = useRouter();
+  const updateImage = useImageStore((state) => state.updateImage);
+  const form = useForm({
+    resolver: zodResolver(imageFormSchema),
+    defaultValues: { image: undefined },
+  });
+
+  React.useEffect(() => {
+    if (image) {
+      form.reset({
+        image: image.storedName?.startsWith('http')
+          ? image.storedName
+          : image.storedName
+            ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${image.storedName}?t=${Date.now()}`
+            : undefined,
+      });
+    }
+  }, [image]);
+
+  async function onSubmit(data) {
+    try {
+      const formData = new FormData();
+      if (data.image?.[0]) {
+        formData.append('file', data.image[0]);
+      }
+      const res = await apiFetch(`/api/v1/admin/images/${image._id}`, {
+        method: 'PUT',
+        body: formData,
+      });
+      const json = await res.json();
+      if (json.success) {
+        toast.success('Image updated successfully');
+        if (json.data) {
+          updateImage(image._id, json.data);
+        }
+        router.push('/admin/blogs/images');
+      } else {
+        toast.error(json.error || 'Failed to update image');
+      }
+    } catch (err) {
+      toast.error('Something went wrong');
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Edit Image</CardTitle>
+        <CardDescription>Replace the image. The name will remain the same.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="image"
+              render={({ field: { onChange, value } }) => (
+                <FormItem>
+                  <FormLabel>New Image</FormLabel>
+                  <FormControl>
+                    <ImageCropperInput
+                      aspectRatio={null}
+                      value={value}
+                      onChange={(val) => {
+                        if (!val || (Array.isArray(val) && val.length === 0)) {
+                          onChange('');
+                        } else {
+                          onChange(val);
+                        }
+                      }}
+                      format="webp"
+                      originalName={true}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+              {form.formState.isSubmitting ? 'Updating...' : 'Update Image'}
+            </Button>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/blogs/images/[id]/edit/loading.jsx
+++ b/app/admin/blogs/images/[id]/edit/loading.jsx
@@ -1,0 +1,5 @@
+import ImageEditSkeleton from "@/components/skeleton/image-edit-skeleton";
+
+export default function Loading() {
+  return <ImageEditSkeleton />;
+}

--- a/app/admin/blogs/images/[id]/edit/page.jsx
+++ b/app/admin/blogs/images/[id]/edit/page.jsx
@@ -1,121 +1,24 @@
 "use client";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import ImageCropperInput from "@/components/image-cropper-input";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import * as z from "zod";
-import { toast } from "sonner";
-import { useRouter } from "next/navigation";
-import React, { useEffect } from "react";
-import apiFetch from "@/helpers/apiFetch";
+import { use as usePromise } from "react";
+import EditImageForm from "./EditImageForm";
+import { useImage } from "@/hooks/use-images";
+import ImageEditSkeleton from "@/components/skeleton/image-edit-skeleton";
 
-const imageFormSchema = z.object({
-  image: z.any().refine((file) => !file || file.length === 1, "Only one image allowed"),
-});
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { image } = useImage(id);
 
-export default function EditImagePage({ params }) {
-  const { id } = React.use(params);
-  const router = useRouter();
+  if (image === undefined) {
+    return <ImageEditSkeleton />;
+  }
 
-  const form = useForm({
-    resolver: zodResolver(imageFormSchema),
-    defaultValues: { image: undefined },
-  });
-
-  // Fetch image data if id is present in URL
-  useEffect(() => {
-    async function fetchImage() {
-      try {
-        const res = await apiFetch(`/api/v1/admin/images/${id}`);
-        const result = await res.json();
-        if (!result.success || !result.data) {
-          router.replace("/admin/blogs/images");
-          return;
-        }
-        // Map API fields to form fields
-        const data = result.data;
-        form.reset({
-          image: data.storedName?.startsWith('http')
-            ? data.storedName
-            : data.storedName
-              ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${data.storedName}?t=${Date.now()}`
-              : undefined,
-        });
-      } catch (err) {
-        router.replace("/admin/blogs/images");
-      }
-    }
-    fetchImage();
-  }, [id]);
-
-  async function onSubmit(data) {
-    try {
-      const formData = new FormData();
-      if (data.image?.[0]) {
-        formData.append('file', data.image[0]);
-      }
-      const res = await apiFetch(`/api/v1/admin/images/${id}`, {
-        method: "PUT",
-        body: formData,
-      });
-      const json = await res.json();
-      if (json.success) {
-        toast.success("Image updated successfully");
-        router.push("/admin/blogs/images");
-      } else {
-        toast.error(json.error || "Failed to update image");
-      }
-    } catch (err) {
-      toast.error("Something went wrong");
-    }
+  if (image === null) {
+    return <div className="p-4">Image not found</div>;
   }
 
   return (
-    <>
-      <div className="w-full p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Edit Image</CardTitle>
-            <CardDescription>Replace the image. The name will remain the same.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-                <FormField
-                  control={form.control}
-                  name="image"
-                  render={({ field: { onChange, value, ...fieldProps } }) => (
-                    <FormItem>
-                      <FormLabel>New Image</FormLabel>
-                      <FormControl>
-                        <ImageCropperInput
-                          aspectRatio={null}
-                          value={value}
-                          onChange={(val) => {
-                            if (!val || (Array.isArray(val) && val.length === 0)) {
-                              onChange("");
-                            } else {
-                              onChange(val);
-                            }
-                          }}
-                          format="webp"
-                          originalName={true}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
-                  {form.formState.isSubmitting ? "Updating..." : "Update Image"}
-                </Button>
-              </form>
-            </Form>
-          </CardContent>
-        </Card>
-      </div>
-    </>
+    <div className="w-full p-4">
+      <EditImageForm image={image} />
+    </div>
   );
 }

--- a/app/admin/blogs/images/add/loading.jsx
+++ b/app/admin/blogs/images/add/loading.jsx
@@ -1,0 +1,5 @@
+import ImageAddSkeleton from "@/components/skeleton/image-add-skeleton";
+
+export default function Loading() {
+  return <ImageAddSkeleton />;
+}

--- a/app/admin/blogs/images/add/page.jsx
+++ b/app/admin/blogs/images/add/page.jsx
@@ -22,6 +22,7 @@ import * as z from "zod";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import apiFetch from "@/helpers/apiFetch";
+import { useImageStore } from "@/app/store/use-image-store";
 
 const imageFormSchema = z.object({
   images: z
@@ -34,6 +35,8 @@ const imageFormSchema = z.object({
 
 export default function AddImagePage() {
   const router = useRouter();
+  const images = useImageStore((state) => state.images);
+  const setImages = useImageStore((state) => state.setImages);
   const form = useForm({
     resolver: zodResolver(imageFormSchema),
     defaultValues: { images: [] },
@@ -53,6 +56,13 @@ export default function AddImagePage() {
       });
       const json = await res.json();
       if (json.success) {
+        if (Array.isArray(json.data) && json.data.length > 0) {
+          const newImgs = json.data.map((img) => ({
+            ...img,
+            _id: img._id || img.id,
+          }));
+          setImages(images ? [...newImgs, ...images] : newImgs);
+        }
         toast.success("Image uploaded successfully");
         router.push("/admin/blogs/images");
       } else {

--- a/app/admin/blogs/images/loading.jsx
+++ b/app/admin/blogs/images/loading.jsx
@@ -1,0 +1,2 @@
+import ImageTableSkeleton from "@/components/skeleton/image-table-skeleton";
+export default ImageTableSkeleton;

--- a/app/admin/blogs/images/page.jsx
+++ b/app/admin/blogs/images/page.jsx
@@ -1,32 +1,33 @@
+"use client";
 import { ImageTable } from "@/components/ImageTable";
-import { cookies } from "next/headers";
-import { hasServerPermission } from "@/helpers/permissions";
+import ImageTableSkeleton from "@/components/skeleton/image-table-skeleton";
+import { useImages } from "@/hooks/use-images";
+import { usePermission } from "@/hooks/use-permission";
 
-export default async function Page() {
-  const store = await cookies();
-  const canAdd = hasServerPermission(store, 'images', 'write');
-  const canEdit = hasServerPermission(store, 'images', 'edit');
+export default function Page() {
+  const { images } = useImages();
+  const canAdd = usePermission('images', 'write');
+  const canEdit = usePermission('images', 'edit');
 
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/images`, { cache: 'no-store' });
-  const json = await res.json();
-  const images = Array.isArray(json?.data) ? json.data : [];
-  const data = images.map(img => ({
-    id: img._id,
-    storedName: img.storedName,
-    uploadedBy: img.uploadedBy,
-    url: img.storedName?.startsWith('http')
-      ? img.storedName
-      : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${img.storedName}?t=${Date.now()}`,
-    createdAt: img.createdAt,
-    // add more fields if needed
-  }));
+  const data = images
+    ? images.map((img) => ({
+        id: img._id,
+        storedName: img.storedName,
+        uploadedBy: img.uploadedBy,
+        url: img.storedName?.startsWith('http')
+          ? img.storedName
+          : `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${img.storedName}?t=${Date.now()}`,
+        createdAt: img.createdAt,
+      }))
+    : [];
 
+  if (!images) {
+    return <ImageTableSkeleton />;
+  }
 
   return (
-    <>
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-        <ImageTable data={data} canAdd={canAdd} canEdit={canEdit} />
-      </div>
-    </>
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <ImageTable data={data} canAdd={canAdd} canEdit={canEdit} />
+    </div>
   );
 }

--- a/app/admin/leads/[id]/edit/loading.jsx
+++ b/app/admin/leads/[id]/edit/loading.jsx
@@ -1,0 +1,5 @@
+import LeadEditSkeleton from "@/components/skeleton/lead-edit-skeleton";
+
+export default function Loading() {
+  return <LeadEditSkeleton />;
+}

--- a/app/admin/leads/[id]/loading.jsx
+++ b/app/admin/leads/[id]/loading.jsx
@@ -1,0 +1,5 @@
+import LeadDetailSkeleton from "@/components/skeleton/lead-detail-skeleton";
+
+export default function Loading() {
+  return <LeadDetailSkeleton />;
+}

--- a/app/admin/leads/[id]/page.jsx
+++ b/app/admin/leads/[id]/page.jsx
@@ -1,19 +1,24 @@
+"use client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { getPublicUrl } from "@/lib/s3";
 import Link from "next/link";
+import { use as usePromise } from "react";
+import { useLead } from "@/hooks/use-leads";
+import LeadDetailSkeleton from "@/components/skeleton/lead-detail-skeleton";
 
-export default async function Page({ params }) {
-  const { id } = await params;
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/${id}`, { cache: 'no-store' });
-  const json = await res.json();
-  const lead = json?.data;
+export default function Page({ params }) {
+  const { id } = usePromise(params);
+  const { lead } = useLead(id);
+  const statusMap = { 1: 'Upcoming', 2: 'Career' };
 
-  if (!lead) {
-    return <div className="p-4">Lead not found</div>;
+  if (lead === undefined) {
+    return <LeadDetailSkeleton />;
   }
 
-  const statusMap = { 1: 'Upcoming', 2: 'Career' };
+  if (lead === null) {
+    return <div className="p-4">Lead not found</div>;
+  }
 
   return (
     <div className="w-full p-4">
@@ -31,7 +36,9 @@ export default async function Page({ params }) {
             <p><strong>Description:</strong> {lead.description}</p>
             <p><strong>Status:</strong> {statusMap[lead.status]}</p>
             {lead.assign_to && <p><strong>Assigned To:</strong> {lead.assign_to}</p>}
-            {lead.assigned_date && <p><strong>Assigned Date:</strong> {new Date(lead.assigned_date).toLocaleString()}</p>}
+            {lead.assigned_date && (
+              <p><strong>Assigned Date:</strong> {new Date(lead.assigned_date).toLocaleString()}</p>
+            )}
             <p><strong>Created:</strong> {new Date(lead.created_date).toLocaleString()}</p>
             {lead.attachments && lead.attachments.length > 0 && (
               <div>

--- a/app/admin/leads/add/loading.jsx
+++ b/app/admin/leads/add/loading.jsx
@@ -1,0 +1,5 @@
+import LeadAddSkeleton from "@/components/skeleton/lead-add-skeleton";
+
+export default function Loading() {
+  return <LeadAddSkeleton />;
+}

--- a/app/admin/leads/career/loading.jsx
+++ b/app/admin/leads/career/loading.jsx
@@ -1,0 +1,5 @@
+import LeadTableSkeleton from "@/components/skeleton/lead-table-skeleton";
+
+export default function Loading() {
+  return <LeadTableSkeleton />;
+}

--- a/app/admin/leads/career/page.jsx
+++ b/app/admin/leads/career/page.jsx
@@ -1,21 +1,28 @@
+"use client";
 import { LeadTable } from "@/components/leadTable";
+import LeadTableSkeleton from "@/components/skeleton/lead-table-skeleton";
+import { useLeads } from "@/hooks/use-leads";
 
-export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/career`, { cache: 'no-store' });
-  const json = await res.json();
-  const leads = Array.isArray(json?.data) ? json.data : [];
-  const data = leads.map(lead => ({
-    id: lead._id,
-    contact_name: lead.contact_name,
-    mobile_number: lead.mobile_number,
-    email: lead.email,
-    organization: lead.organization,
-    requirements: lead.requirements,
-    status: 'career',
-    created_date: lead.created_date,
-    assign_to: lead.assign_to,
-    attachments: lead.attachments,
-  }));
+export default function Page() {
+  const { leads } = useLeads('career');
+  const data = leads
+    ? leads.map((lead) => ({
+        id: lead._id,
+        contact_name: lead.contact_name,
+        mobile_number: lead.mobile_number,
+        email: lead.email,
+        organization: lead.organization,
+        requirements: lead.requirements,
+        status: 'career',
+        created_date: lead.created_date,
+        assign_to: lead.assign_to,
+        attachments: lead.attachments,
+      }))
+    : [];
+
+  if (!leads) {
+    return <LeadTableSkeleton />;
+  }
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/leads/loading.jsx
+++ b/app/admin/leads/loading.jsx
@@ -1,0 +1,5 @@
+import LeadTableSkeleton from "@/components/skeleton/lead-table-skeleton";
+
+export default function Loading() {
+  return <LeadTableSkeleton />;
+}

--- a/app/admin/leads/page.jsx
+++ b/app/admin/leads/page.jsx
@@ -1,22 +1,29 @@
+"use client";
 import { LeadTable } from "@/components/leadTable";
+import LeadTableSkeleton from "@/components/skeleton/lead-table-skeleton";
+import { useLeads } from "@/hooks/use-leads";
 
-export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/leads/upcoming`, { cache: 'no-store' });
-  const json = await res.json();
-  const leads = Array.isArray(json?.data) ? json.data : [];
+export default function Page() {
+  const { leads } = useLeads('upcoming');
   const statusMap = { 1: 'upcoming', 2: 'career' };
-  const data = leads.map(lead => ({
-    id: lead._id,
-    contact_name: lead.contact_name,
-    mobile_number: lead.mobile_number,
-    email: lead.email,
-    organization: lead.organization,
-    requirements: lead.requirements,
-    status: statusMap[lead.status] || 'upcoming',
-    created_date: lead.created_date,
-    assign_to: lead.assign_to,
-    attachments: lead.attachments,
-  }));
+  const data = leads
+    ? leads.map((lead) => ({
+        id: lead._id,
+        contact_name: lead.contact_name,
+        mobile_number: lead.mobile_number,
+        email: lead.email,
+        organization: lead.organization,
+        requirements: lead.requirements,
+        status: statusMap[lead.status] || 'upcoming',
+        created_date: lead.created_date,
+        assign_to: lead.assign_to,
+        attachments: lead.attachments,
+      }))
+    : [];
+
+  if (!leads) {
+    return <LeadTableSkeleton />;
+  }
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/loading.jsx
+++ b/app/admin/loading.jsx
@@ -1,0 +1,5 @@
+import DashboardSkeleton from "@/components/skeleton/dashboard-skeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/app/admin/meta/static/loading.jsx
+++ b/app/admin/meta/static/loading.jsx
@@ -1,0 +1,5 @@
+import StaticMetaSkeleton from '@/components/skeleton/static-meta-skeleton'
+
+export default function Loading() {
+  return <StaticMetaSkeleton />
+}

--- a/app/admin/meta/static/page.jsx
+++ b/app/admin/meta/static/page.jsx
@@ -1,28 +1,17 @@
-import EditStaticMetaForm from './EditStaticMetaForm';
+"use client";
+import EditStaticMetaForm from "./EditStaticMetaForm";
+import StaticMetaSkeleton from "@/components/skeleton/static-meta-skeleton";
+import { useStaticMeta } from "@/hooks/use-meta";
 
-export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/static`, { cache: 'no-store' });
-  const json = await res.json();
-  const meta = json?.data || null;
+export default function Page() {
+  const { meta, loading, error } = useStaticMeta();
 
-  const toUrl = (name) =>
-    name && !name.startsWith('http')
-      ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${name}`
-      : name;
-  if (meta) {
-    meta.appleWebApp.startupImage.mainImageUrl = toUrl(
-      meta.appleWebApp.startupImage.mainImageUrl
-    );
-    meta.appleWebApp.startupImage.url = toUrl(meta.appleWebApp.startupImage.url);
-    meta.icons.icon = meta.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }));
-    meta.icons.shortcut = toUrl(meta.icons.shortcut);
-    meta.icons.apple = toUrl(meta.icons.apple);
-    meta.icons.other = meta.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }));
-    meta.twitter.images = meta.twitter.images.map(toUrl);
-    meta.openGraph.images = meta.openGraph.images.map((img) => ({
-      ...img,
-      url: toUrl(img.url),
-    }));
+  if (loading) {
+    return <StaticMetaSkeleton />;
+  }
+
+  if (!meta) {
+    return <div className="p-4">{error || 'Static meta not found'}</div>;
   }
 
   return (

--- a/app/admin/newsletter/add/loading.jsx
+++ b/app/admin/newsletter/add/loading.jsx
@@ -1,0 +1,5 @@
+import NewsletterAddSkeleton from "@/components/skeleton/newsletter-add-skeleton";
+
+export default function Loading() {
+  return <NewsletterAddSkeleton />;
+}

--- a/app/admin/newsletter/add/page.jsx
+++ b/app/admin/newsletter/add/page.jsx
@@ -9,11 +9,14 @@ import * as z from "zod";
 import apiFetch from "@/helpers/apiFetch";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
+import { useNewsletterStore } from "@/app/store/use-newsletter-store";
 
 const schema = z.object({ email: z.string().email() });
 
 export default function Page() {
   const router = useRouter();
+  const setNewsletters = useNewsletterStore((state) => state.setNewsletters);
+  const newsletters = useNewsletterStore((state) => state.newsletters);
   const form = useForm({ resolver: zodResolver(schema), defaultValues: { email: "" } });
 
   async function onSubmit(values) {
@@ -21,9 +24,11 @@ export default function Page() {
     const result = await res.json();
     if (result.success) {
       toast.success('Subscribed');
+      if (result.data) {
+        setNewsletters(newsletters ? [result.data, ...newsletters] : [result.data]);
+      }
       form.reset();
       router.push('/admin/newsletter');
-      router.refresh();
     } else {
       toast.error(result.error || 'Failed');
     }

--- a/app/admin/newsletter/loading.jsx
+++ b/app/admin/newsletter/loading.jsx
@@ -1,0 +1,5 @@
+import NewsletterTableSkeleton from "@/components/skeleton/newsletter-table-skeleton";
+
+export default function Loading() {
+  return <NewsletterTableSkeleton />;
+}

--- a/app/admin/newsletter/page.jsx
+++ b/app/admin/newsletter/page.jsx
@@ -1,14 +1,21 @@
+"use client";
 import { NewsletterTable } from "@/components/newsletterTable";
+import NewsletterTableSkeleton from "@/components/skeleton/newsletter-table-skeleton";
+import { useNewsletters } from "@/hooks/use-newsletters";
 
-export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/newsletters`, { cache: 'no-store' });
-  const json = await res.json();
-  const newsletters = Array.isArray(json?.data) ? json.data : [];
-  const data = newsletters.map(n => ({
-    id: n._id,
-    email: n.email,
-    createdAt: n.createdAt,
-  }));
+export default function Page() {
+  const { newsletters } = useNewsletters();
+  const data = newsletters
+    ? newsletters.map((n) => ({
+        id: n._id,
+        email: n.email,
+        createdAt: n.createdAt,
+      }))
+    : [];
+
+  if (!newsletters) {
+    return <NewsletterTableSkeleton />;
+  }
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -1,9 +1,16 @@
+"use client";
 import { SectionCards } from "@/components/section-cards";
-import { getDashboardStats } from "@/app/actions/dashboard";
 import { ChartAreaInteractive } from "@/components/chart-area-interactive";
+import DashboardSkeleton from "@/components/skeleton/dashboard-skeleton";
+import { useDashboard } from "@/hooks/use-dashboard";
 
-export default async function Page() {
-  const stats = await getDashboardStats();
+export default function Page() {
+  const { stats } = useDashboard();
+
+  if (!stats) {
+    return <DashboardSkeleton />;
+  }
+
   return (
     <div className="grid gap-4 p-4">
       <SectionCards stats={stats} />

--- a/app/admin/schema/[slug]/add/loading.jsx
+++ b/app/admin/schema/[slug]/add/loading.jsx
@@ -1,0 +1,5 @@
+import SchemaAddSkeleton from '@/components/skeleton/schema-add-skeleton'
+
+export default function Loading() {
+  return <SchemaAddSkeleton />
+}

--- a/app/admin/schema/loading.jsx
+++ b/app/admin/schema/loading.jsx
@@ -1,0 +1,5 @@
+import SchemaTableSkeleton from '@/components/skeleton/schema-table-skeleton'
+
+export default function Loading() {
+  return <SchemaTableSkeleton />
+}

--- a/app/admin/schema/page.jsx
+++ b/app/admin/schema/page.jsx
@@ -1,13 +1,15 @@
+"use client";
 import { SchemaPageTable } from '@/components/schemaPageTable';
+import SchemaTableSkeleton from '@/components/skeleton/schema-table-skeleton';
+import { useSchemaPages } from '@/hooks/use-schema-pages';
 
-async function getPages() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/pages`, { cache: 'no-store' });
-  const json = await res.json();
-  return Array.isArray(json.data) ? json.data : [];
-}
+export default function Page() {
+  const { pages } = useSchemaPages();
 
-export default async function Page() {
-  const pages = await getPages();
+  if (!pages) {
+    return <SchemaTableSkeleton />;
+  }
+
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
       <SchemaPageTable data={pages} />

--- a/app/api/v1/admin/admins/me/route.js
+++ b/app/api/v1/admin/admins/me/route.js
@@ -7,7 +7,7 @@ import Admin from '@/app/models/Admin';
 export async function GET(req) {
   let token = extractToken(req.headers);
   if (!token) {
-    const cookieStore = cookies();
+    const cookieStore = await cookies();
     token = cookieStore.get('token')?.value || null;
   }
   if (!token) {

--- a/app/api/v1/admin/dashboard/route.js
+++ b/app/api/v1/admin/dashboard/route.js
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import { getDashboardStats } from '@/app/actions/dashboard'
+
+export async function GET() {
+  try {
+    const stats = await getDashboardStats()
+    return NextResponse.json({ success: true, data: stats })
+  } catch (err) {
+    console.error('Failed to load dashboard stats:', err)
+    return NextResponse.json({ success: false }, { status: 500 })
+  }
+}

--- a/app/api/v1/admin/departments/[id]/route.js
+++ b/app/api/v1/admin/departments/[id]/route.js
@@ -6,10 +6,11 @@ import { ensurePermission } from '@/lib/rbac';
 import { syncAdminsFromDB } from '@/app/lib/adminsFile';
 
 export async function GET(req, { params }) {
+  const { id } = await params;
   const admin = await ensurePermission(req, 'departments', 'read');
   if (!admin) return NextResponse.json({ success: false, error: 'Permission denied' }, { status: 403 });
   await connectDB();
-  const dept = await Department.findById(params.id).lean();
+  const dept = await Department.findById(id).lean();
   if (!dept) return NextResponse.json({ success: false, error: 'Department not found' }, { status: 404 });
   return NextResponse.json({ success: true, data: dept });
 }

--- a/app/store/use-author-store.js
+++ b/app/store/use-author-store.js
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+
+export const useAuthorStore = create((set) => ({
+  authors: null,
+  authorDetails: {},
+  setAuthors: (authors) => set({ authors }),
+  setAuthorDetail: (id, author) =>
+    set((state) => ({
+      authorDetails: { ...state.authorDetails, [id]: author },
+    })),
+  updateAuthor: (id, updates) =>
+    set((state) => {
+      const authors = state.authors
+        ? state.authors.map((a) =>
+            (a._id || a.id) === id ? { ...a, ...updates } : a
+          )
+        : null
+      const detail = state.authorDetails[id]
+      return {
+        authors,
+        authorDetails: detail
+          ? { ...state.authorDetails, [id]: { ...detail, ...updates } }
+          : state.authorDetails,
+      }
+    }),
+  clearAuthors: () => set({ authors: null }),
+  removeAuthor: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.authorDetails
+      return { authorDetails: rest }
+    }),
+}))

--- a/app/store/use-category-store.js
+++ b/app/store/use-category-store.js
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+
+export const useCategoryStore = create((set) => ({
+  categories: null,
+  categoryDetails: {},
+  setCategories: (cats) => set({ categories: cats }),
+  setCategoryDetail: (id, cat) =>
+    set((state) => ({
+      categoryDetails: { ...state.categoryDetails, [id]: cat },
+    })),
+  updateCategory: (id, updates) =>
+    set((state) => {
+      const categories = state.categories
+        ? state.categories.map((c) =>
+            (c._id || c.id) === id ? { ...c, ...updates } : c
+          )
+        : null;
+      const detail = state.categoryDetails[id];
+      return {
+        categories,
+        categoryDetails: detail
+          ? { ...state.categoryDetails, [id]: { ...detail, ...updates } }
+          : state.categoryDetails,
+      };
+    }),
+  clearCategories: () => set({ categories: null }),
+  removeCategory: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.categoryDetails
+      return { categoryDetails: rest }
+    }),
+}))

--- a/app/store/use-dashboard-store.js
+++ b/app/store/use-dashboard-store.js
@@ -1,0 +1,7 @@
+import { create } from 'zustand'
+
+export const useDashboardStore = create((set) => ({
+  stats: null,
+  setStats: (stats) => set({ stats }),
+  clearStats: () => set({ stats: null }),
+}))

--- a/app/store/use-image-store.js
+++ b/app/store/use-image-store.js
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+
+export const useImageStore = create((set) => ({
+  images: null,
+  imageDetails: {},
+  setImages: (images) => set({ images }),
+  setImageDetail: (id, image) =>
+    set((state) => ({
+      imageDetails: { ...state.imageDetails, [id]: image },
+    })),
+  updateImage: (id, updates) =>
+    set((state) => {
+      const images = state.images
+        ? state.images.map((img) =>
+            (img._id || img.id) === id ? { ...img, ...updates } : img
+          )
+        : null
+      const detail = state.imageDetails[id]
+      return {
+        images,
+        imageDetails: detail
+          ? { ...state.imageDetails, [id]: { ...detail, ...updates } }
+          : state.imageDetails,
+      }
+    }),
+  clearImages: () => set({ images: null }),
+  removeImage: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.imageDetails
+      return { imageDetails: rest }
+    }),
+}))

--- a/app/store/use-lead-store.js
+++ b/app/store/use-lead-store.js
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+
+export const useLeadStore = create((set) => ({
+  upcoming: null,
+  career: null,
+  leadDetails: {},
+  setUpcoming: (leads) => set({ upcoming: leads }),
+  setCareer: (leads) => set({ career: leads }),
+  setLeadDetail: (id, lead) =>
+    set((state) => ({
+      leadDetails: { ...state.leadDetails, [id]: lead },
+    })),
+  updateLead: (id, updates) =>
+    set((state) => {
+      const updateArray = (arr) =>
+        arr ? arr.map((l) => ((l._id || l.id) === id ? { ...l, ...updates } : l)) : null
+      return {
+        upcoming: updateArray(state.upcoming),
+        career: updateArray(state.career),
+        leadDetails: state.leadDetails[id]
+          ? { ...state.leadDetails, [id]: { ...state.leadDetails[id], ...updates } }
+          : state.leadDetails,
+      }
+    }),
+  clearUpcoming: () => set({ upcoming: null }),
+  clearCareer: () => set({ career: null }),
+  removeLead: (id) =>
+    set((state) => {
+      const { [id]: removed, ...rest } = state.leadDetails
+      return { leadDetails: rest }
+    }),
+}))
+

--- a/app/store/use-meta-store.js
+++ b/app/store/use-meta-store.js
@@ -1,0 +1,9 @@
+import { create } from 'zustand'
+
+export const useMetaStore = create((set) => ({
+  staticMeta: null,
+  setStaticMeta: (meta) => set({ staticMeta: meta }),
+  updateStaticMeta: (updates) =>
+    set((state) => ({ staticMeta: state.staticMeta ? { ...state.staticMeta, ...updates } : null })),
+  clearStaticMeta: () => set({ staticMeta: null }),
+}))

--- a/app/store/use-newsletter-store.js
+++ b/app/store/use-newsletter-store.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand'
+
+export const useNewsletterStore = create((set) => ({
+  newsletters: null,
+  setNewsletters: (data) => set({ newsletters: data }),
+  clearNewsletters: () => set({ newsletters: null }),
+}))
+

--- a/app/store/use-schema-store.js
+++ b/app/store/use-schema-store.js
@@ -1,0 +1,7 @@
+import { create } from 'zustand'
+
+export const useSchemaStore = create((set) => ({
+  pages: null,
+  setPages: (pages) => set({ pages }),
+  clearPages: () => set({ pages: null }),
+}))

--- a/components/authorTable.jsx
+++ b/components/authorTable.jsx
@@ -38,12 +38,12 @@ import { Badge } from "@/components/ui/badge"
 import Image from "next/image"
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import apiFetch from "@/helpers/apiFetch"
+import { useAuthorStore } from "@/app/store/use-author-store"
 
 function AuthorActions({ author, canEdit }) {
-  const router = useRouter()
+  const updateAuthor = useAuthorStore(state => state.updateAuthor)
 
   const handleStatusChange = async (status) => {
     try {
@@ -56,7 +56,7 @@ function AuthorActions({ author, canEdit }) {
       const data = await res.json()
       if (data.success) {
         toast.success('Status updated')
-        router.refresh()
+        updateAuthor(author.id, { status })
       } else {
         toast.error(data.error || 'Failed to update status')
       }

--- a/components/category-store-initializer.jsx
+++ b/components/category-store-initializer.jsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect } from "react";
+import { useCategoryStore } from "@/app/store/use-category-store";
+
+export default function CategoryStoreInitializer({ categories, category }) {
+  const setCategories = useCategoryStore((state) => state.setCategories);
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail);
+
+  useEffect(() => {
+    if (categories) {
+      setCategories(categories);
+    }
+  }, [categories, setCategories]);
+
+  useEffect(() => {
+    if (category) {
+      setCategoryDetail(category._id || category.id, category);
+    }
+  }, [category, setCategoryDetail]);
+
+  return null;
+}

--- a/components/categoryTable.jsx
+++ b/components/categoryTable.jsx
@@ -35,12 +35,12 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useCategoryStore } from "@/app/store/use-category-store";
 
 function CategoryActions({ category, canEdit }) {
-  const router = useRouter();
+  const updateCategory = useCategoryStore(state => state.updateCategory);
 
   const handleStatusChange = async (status) => {
     try {
@@ -53,7 +53,7 @@ function CategoryActions({ category, canEdit }) {
       const data = await res.json();
       if (data.success) {
         toast.success('Status updated');
-        router.refresh();
+        updateCategory(category.id, { status });
       } else {
         toast.error(data.error || 'Failed to update status');
       }

--- a/components/delete-author-buttons.jsx
+++ b/components/delete-author-buttons.jsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useAuthor } from "@/hooks/use-authors";
+import { useAuthorStore } from "@/app/store/use-author-store";
 import { Copy } from "lucide-react";
 import Link from "next/link";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -14,6 +16,8 @@ export default function DeleteAuthorButtons({ id }) {
   const [open, setOpen] = useState(false);
   const [blogs, setBlogs] = useState(null);
   const [loading, setLoading] = useState(false);
+  useAuthor(id); // preload for cache update
+  const removeAuthor = useAuthorStore(state => state.removeAuthor);
 
   const handleOpen = async () => {
     setOpen(true);
@@ -33,6 +37,7 @@ export default function DeleteAuthorButtons({ id }) {
       });
       const data = await res.json();
       if (data.success) {
+        removeAuthor(id);
         toast.success(data.message || "Author deleted");
         router.push("/admin/blogs/authors");
       } else {

--- a/components/delete-category-buttons.jsx
+++ b/components/delete-category-buttons.jsx
@@ -5,6 +5,8 @@ import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, Dialo
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useCategory } from "@/hooks/use-categories";
+import { useCategoryStore } from "@/app/store/use-category-store";
 import { Copy } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
@@ -14,6 +16,8 @@ export default function DeleteCategoryButtons({ id }) {
   const [open, setOpen] = useState(false);
   const [blogs, setBlogs] = useState(null);
   const [loading, setLoading] = useState(false);
+  useCategory(id); // preload for cache update
+  const removeCategory = useCategoryStore(state => state.removeCategory);
 
   const handleOpen = async () => {
     setOpen(true);
@@ -33,6 +37,7 @@ export default function DeleteCategoryButtons({ id }) {
       });
       const data = await res.json();
       if (data.success) {
+        removeCategory(id);
         toast.success(data.message || "Category deleted");
         router.push("/admin/blogs/categories");
       } else {

--- a/components/skeleton/author-detail-skeleton.jsx
+++ b/components/skeleton/author-detail-skeleton.jsx
@@ -1,0 +1,31 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AuthorDetailSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-6">
+            <Skeleton className="h-[120px] w-[120px] rounded-lg" />
+            <div className="flex-1 space-y-2 text-sm">
+              {[...Array(7)].map((_, i) => (
+                <Skeleton key={i} className="h-4 w-full" />
+              ))}
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/author-edit-skeleton.jsx
+++ b/components/skeleton/author-edit-skeleton.jsx
@@ -1,0 +1,47 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AuthorEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="grid md:grid-cols-3 gap-6">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/author-table-skeleton.jsx
+++ b/components/skeleton/author-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function AuthorTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(7)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(7)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/category-detail-skeleton.jsx
+++ b/components/skeleton/category-detail-skeleton.jsx
@@ -1,0 +1,28 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function CategoryDetailSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(5)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/category-edit-skeleton.jsx
+++ b/components/skeleton/category-edit-skeleton.jsx
@@ -1,0 +1,39 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function CategoryEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/category-table-skeleton.jsx
+++ b/components/skeleton/category-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function CategoryTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(6)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(6)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/dashboard-skeleton.jsx
+++ b/components/skeleton/dashboard-skeleton.jsx
@@ -1,0 +1,36 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function DashboardSkeleton() {
+  return (
+    <div className="grid gap-4 p-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <CardTitle>
+                <Skeleton className="h-6 w-32" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-8 w-20" />
+              <Skeleton className="h-4 w-16" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Card className="@container/card">
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
+          <Skeleton className="h-[250px] w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/image-add-skeleton.jsx
+++ b/components/skeleton/image-add-skeleton.jsx
@@ -1,0 +1,31 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function ImageAddSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/image-edit-skeleton.jsx
+++ b/components/skeleton/image-edit-skeleton.jsx
@@ -1,0 +1,31 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function ImageEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/image-table-skeleton.jsx
+++ b/components/skeleton/image-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function ImageTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(5)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(5)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/lead-add-skeleton.jsx
+++ b/components/skeleton/lead-add-skeleton.jsx
@@ -1,0 +1,37 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function LeadAddSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/lead-detail-skeleton.jsx
+++ b/components/skeleton/lead-detail-skeleton.jsx
@@ -1,0 +1,28 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function LeadDetailSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2 text-sm">
+            {[...Array(10)].map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Skeleton className="h-10 w-20" />
+            <Skeleton className="h-10 w-24" />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/lead-edit-skeleton.jsx
+++ b/components/skeleton/lead-edit-skeleton.jsx
@@ -1,0 +1,37 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function LeadEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/lead-table-skeleton.jsx
+++ b/components/skeleton/lead-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function LeadTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(9)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(9)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/newsletter-add-skeleton.jsx
+++ b/components/skeleton/newsletter-add-skeleton.jsx
@@ -1,0 +1,32 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function NewsletterAddSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/components/skeleton/newsletter-table-skeleton.jsx
+++ b/components/skeleton/newsletter-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function NewsletterTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(4)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(4)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/schema-add-skeleton.jsx
+++ b/components/skeleton/schema-add-skeleton.jsx
@@ -1,0 +1,34 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function SchemaAddSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/schema-table-skeleton.jsx
+++ b/components/skeleton/schema-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function SchemaTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(4)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(4)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/static-meta-skeleton.jsx
+++ b/components/skeleton/static-meta-skeleton.jsx
@@ -1,0 +1,30 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function StaticMetaSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {[...Array(8)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/hooks/use-authors.js
+++ b/hooks/use-authors.js
@@ -1,0 +1,55 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useAuthorStore } from '@/app/store/use-author-store'
+
+export function useAuthors() {
+  const authors = useAuthorStore((state) => state.authors)
+  const setAuthors = useAuthorStore((state) => state.setAuthors)
+  const clearAuthors = useAuthorStore((state) => state.clearAuthors)
+  const [loading, setLoading] = useState(!authors)
+
+  const refresh = useCallback(() => {
+    clearAuthors()
+  }, [clearAuthors])
+
+  useEffect(() => {
+    if (!authors) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/blogs/authors')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setAuthors(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [authors, setAuthors])
+
+  return { authors, loading, refresh }
+}
+
+export function useAuthor(id) {
+  const author = useAuthorStore((state) => state.authorDetails[id])
+  const setAuthorDetail = useAuthorStore((state) => state.setAuthorDetail)
+  const removeAuthor = useAuthorStore((state) => state.removeAuthor)
+  const [loading, setLoading] = useState(!author && !!id)
+
+  const refresh = useCallback(() => {
+    removeAuthor(id)
+  }, [removeAuthor, id])
+
+  useEffect(() => {
+    if (id && !author) {
+      setLoading(true)
+      apiFetch(`/api/v1/admin/blogs/authors/${id}`)
+        .then((res) => res.json())
+        .then((json) => {
+          setAuthorDetail(id, json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [id, author, setAuthorDetail])
+
+  return { author, loading, refresh }
+}

--- a/hooks/use-categories.js
+++ b/hooks/use-categories.js
@@ -1,0 +1,55 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useCategoryStore } from '@/app/store/use-category-store'
+
+export function useCategories() {
+  const categories = useCategoryStore((state) => state.categories)
+  const setCategories = useCategoryStore((state) => state.setCategories)
+  const clearCategories = useCategoryStore((state) => state.clearCategories)
+  const [loading, setLoading] = useState(!categories)
+
+  const refresh = useCallback(() => {
+    clearCategories()
+  }, [clearCategories])
+
+  useEffect(() => {
+    if (!categories) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/blogs/categories')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setCategories(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [categories, setCategories])
+
+  return { categories, loading, refresh }
+}
+
+export function useCategory(id) {
+  const category = useCategoryStore((state) => state.categoryDetails[id])
+  const setCategoryDetail = useCategoryStore((state) => state.setCategoryDetail)
+  const removeCategory = useCategoryStore((state) => state.removeCategory)
+  const [loading, setLoading] = useState(!category && !!id)
+
+  const refresh = useCallback(() => {
+    removeCategory(id)
+  }, [removeCategory, id])
+
+  useEffect(() => {
+    if (id && !category) {
+      setLoading(true)
+      apiFetch(`/api/v1/admin/blogs/categories/${id}`)
+        .then((res) => res.json())
+        .then((json) => {
+          setCategoryDetail(id, json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [id, category, setCategoryDetail])
+
+  return { category, loading, refresh }
+}

--- a/hooks/use-dashboard.js
+++ b/hooks/use-dashboard.js
@@ -1,0 +1,30 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useDashboardStore } from '@/app/store/use-dashboard-store'
+
+export function useDashboard() {
+  const stats = useDashboardStore((state) => state.stats)
+  const setStats = useDashboardStore((state) => state.setStats)
+  const clearStats = useDashboardStore((state) => state.clearStats)
+  const [loading, setLoading] = useState(!stats)
+
+  const refresh = useCallback(() => {
+    clearStats()
+  }, [clearStats])
+
+  useEffect(() => {
+    if (!stats) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/dashboard')
+        .then((res) => res.json())
+        .then((json) => {
+          if (json?.data) {
+            setStats(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [stats, setStats])
+
+  return { stats, loading, refresh }
+}

--- a/hooks/use-images.js
+++ b/hooks/use-images.js
@@ -1,0 +1,55 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useImageStore } from '@/app/store/use-image-store'
+
+export function useImages() {
+  const images = useImageStore((state) => state.images)
+  const setImages = useImageStore((state) => state.setImages)
+  const clearImages = useImageStore((state) => state.clearImages)
+  const [loading, setLoading] = useState(!images)
+
+  const refresh = useCallback(() => {
+    clearImages()
+  }, [clearImages])
+
+  useEffect(() => {
+    if (!images) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/images')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setImages(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [images, setImages])
+
+  return { images, loading, refresh }
+}
+
+export function useImage(id) {
+  const image = useImageStore((state) => state.imageDetails[id])
+  const setImageDetail = useImageStore((state) => state.setImageDetail)
+  const removeImage = useImageStore((state) => state.removeImage)
+  const [loading, setLoading] = useState(!image && !!id)
+
+  const refresh = useCallback(() => {
+    removeImage(id)
+  }, [removeImage, id])
+
+  useEffect(() => {
+    if (id && !image) {
+      setLoading(true)
+      apiFetch(`/api/v1/admin/images/${id}`)
+        .then((res) => res.json())
+        .then((json) => {
+          setImageDetail(id, json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [id, image, setImageDetail])
+
+  return { image, loading, refresh }
+}

--- a/hooks/use-leads.js
+++ b/hooks/use-leads.js
@@ -1,0 +1,61 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useLeadStore } from '@/app/store/use-lead-store'
+
+export function useLeads(type = 'upcoming') {
+  const leads = useLeadStore((state) => state[type])
+  const set = useLeadStore((state) =>
+    type === 'career' ? state.setCareer : state.setUpcoming
+  )
+  const clear = useLeadStore((state) =>
+    type === 'career' ? state.clearCareer : state.clearUpcoming
+  )
+  const [loading, setLoading] = useState(!leads)
+
+  const refresh = useCallback(() => {
+    clear()
+  }, [clear])
+
+  useEffect(() => {
+    if (!leads) {
+      setLoading(true)
+      const endpoint = type === 'career' ? '/api/v1/admin/leads/career' : '/api/v1/admin/leads/upcoming'
+      apiFetch(endpoint)
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            set(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [leads, set, type])
+
+  return { leads, loading, refresh }
+}
+
+export function useLead(id) {
+  const lead = useLeadStore((state) => state.leadDetails[id])
+  const setLeadDetail = useLeadStore((state) => state.setLeadDetail)
+  const removeLead = useLeadStore((state) => state.removeLead)
+  const [loading, setLoading] = useState(!lead && !!id)
+
+  const refresh = useCallback(() => {
+    removeLead(id)
+  }, [removeLead, id])
+
+  useEffect(() => {
+    if (id && !lead) {
+      setLoading(true)
+      apiFetch(`/api/v1/admin/leads/${id}`)
+        .then((res) => res.json())
+        .then((json) => {
+          setLeadDetail(id, json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [id, lead, setLeadDetail])
+
+  return { lead, loading, refresh }
+}
+

--- a/hooks/use-meta.js
+++ b/hooks/use-meta.js
@@ -1,0 +1,63 @@
+import { useEffect, useState, useCallback, useRef } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useMetaStore } from '@/app/store/use-meta-store'
+
+function addImageUrls(meta) {
+  if (!meta) return meta
+  const toUrl = (name) =>
+    name && !name.startsWith('http')
+      ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${name}`
+      : name
+
+  meta.appleWebApp.startupImage.mainImageUrl = toUrl(
+    meta.appleWebApp.startupImage.mainImageUrl
+  )
+  meta.appleWebApp.startupImage.url = toUrl(meta.appleWebApp.startupImage.url)
+  meta.icons.icon = meta.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }))
+  meta.icons.shortcut = toUrl(meta.icons.shortcut)
+  meta.icons.apple = toUrl(meta.icons.apple)
+  meta.icons.other = meta.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }))
+  meta.twitter.images = meta.twitter.images.map(toUrl)
+  meta.openGraph.images = meta.openGraph.images.map((img) => ({
+    ...img,
+    url: toUrl(img.url),
+  }))
+  return meta
+}
+
+export function useStaticMeta() {
+  const meta = useMetaStore((state) => state.staticMeta)
+  const setMeta = useMetaStore((state) => state.setStaticMeta)
+  const clearMeta = useMetaStore((state) => state.clearStaticMeta)
+  const [loading, setLoading] = useState(!meta)
+  const [error, setError] = useState(null)
+  const fetched = useRef(false)
+
+  const refresh = useCallback(() => {
+    clearMeta()
+    setError(null)
+    fetched.current = false
+    setLoading(true)
+  }, [clearMeta])
+
+  useEffect(() => {
+    if (!meta && !fetched.current) {
+      fetched.current = true
+      setLoading(true)
+      apiFetch('/api/v1/admin/meta/static')
+        .then((res) => res.json())
+        .then((json) => {
+          if (json?.data) {
+            setMeta(addImageUrls(json.data))
+          } else {
+            setMeta(null)
+            setError(json.error || 'Static meta not found')
+          }
+        })
+        .catch(() => setError('Failed to load static meta'))
+        .finally(() => setLoading(false))
+    }
+  }, [meta, setMeta])
+
+  return { meta, loading, error, refresh }
+}

--- a/hooks/use-newsletters.js
+++ b/hooks/use-newsletters.js
@@ -1,0 +1,31 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useNewsletterStore } from '@/app/store/use-newsletter-store'
+
+export function useNewsletters() {
+  const newsletters = useNewsletterStore((state) => state.newsletters)
+  const setNewsletters = useNewsletterStore((state) => state.setNewsletters)
+  const clearNewsletters = useNewsletterStore((state) => state.clearNewsletters)
+  const [loading, setLoading] = useState(!newsletters)
+
+  const refresh = useCallback(() => {
+    clearNewsletters()
+  }, [clearNewsletters])
+
+  useEffect(() => {
+    if (!newsletters) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/newsletters')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setNewsletters(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [newsletters, setNewsletters])
+
+  return { newsletters, loading, refresh }
+}
+

--- a/hooks/use-schema-pages.js
+++ b/hooks/use-schema-pages.js
@@ -1,0 +1,30 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useSchemaStore } from '@/app/store/use-schema-store'
+
+export function useSchemaPages() {
+  const pages = useSchemaStore((state) => state.pages)
+  const setPages = useSchemaStore((state) => state.setPages)
+  const clearPages = useSchemaStore((state) => state.clearPages)
+  const [loading, setLoading] = useState(!pages)
+
+  const refresh = useCallback(() => {
+    clearPages()
+  }, [clearPages])
+
+  useEffect(() => {
+    if (!pages) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/pages')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setPages(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [pages, setPages])
+
+  return { pages, loading, refresh }
+}


### PR DESCRIPTION
## Summary
- create Zustand stores and hooks for leads and newsletters
- add shadcn skeletons and loading routes for leads and newsletter pages
- convert leads and newsletter pages to client components using the new hooks
- update add/edit logic to cache results in Zustand
- add Zustand stores and skeleton UIs for meta and schema modules
- handle missing static meta and show not found message

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864cebdfd888328a1ce9a14a0712267