### PR TITLE
Add PWA push notification support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your_public_key_here
+VAPID_PRIVATE_KEY=your_private_key_here
+MONGODB_URI=

--- a/app/(frontend)/page.jsx
+++ b/app/(frontend)/page.jsx
@@ -26,6 +26,8 @@ const Testimonial = dynamic(() => import('@/components/testimonials/Testimonial1
 })
 import Faq from '@/components/Faq';
 import HomeHeroSkeleton from '@/components/skeleton/HomeHeroSkeleton';
+import PushNotificationManager from '@/components/push/PushNotificationManager';
+import InstallPrompt from '@/components/push/InstallPrompt';
 
 export const metadata = {
     title: "Mobile App Development & IT Consulting Services in USA | IMG Global Infotech",
@@ -300,6 +302,8 @@ export default function Home() {
       <Usp/>
       <Testimonial/>
       <Faq/>
+      <PushNotificationManager />
+      <InstallPrompt />
     </>
   );
 }

--- a/app/lib/db.js
+++ b/app/lib/db.js
@@ -37,4 +37,4 @@ async function connectDB() {
   return cached.conn;
 }
 
-export default connectDB; 
+export default connectDB;

--- a/app/models/PushSubscriber.js
+++ b/app/models/PushSubscriber.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const pushSubscriberSchema = new mongoose.Schema({
+  endpoint: { type: String, required: true, unique: true },
+  keys: {
+    p256dh: { type: String, required: true },
+    auth: { type: String, required: true }
+  }
+});
+
+const PushSubscriber = mongoose.models.PushSubscriber || mongoose.model('PushSubscriber', pushSubscriberSchema);
+export default PushSubscriber;

--- a/app/pushActions.js
+++ b/app/pushActions.js
@@ -1,8 +1,8 @@
 'use server';
 
 import webpush from 'web-push';
-import connectDB from '@/app/lib/db';
-import PushSubscriber from '@/app/models/PushSubscriber';
+import connectDB from './lib/db';
+import PushSubscriber from './models/PushSubscriber';
 
 webpush.setVapidDetails(
   'mailto:your-email@example.com',

--- a/app/pushActions.js
+++ b/app/pushActions.js
@@ -1,0 +1,41 @@
+'use server';
+
+import webpush from 'web-push';
+
+webpush.setVapidDetails(
+  'mailto:your-email@example.com',
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+  process.env.VAPID_PRIVATE_KEY
+);
+
+let subscription = null;
+
+export async function subscribeUser(sub) {
+  subscription = sub;
+  return { success: true };
+}
+
+export async function unsubscribeUser() {
+  subscription = null;
+  return { success: true };
+}
+
+export async function sendNotification(message) {
+  if (!subscription) {
+    throw new Error('No subscription available');
+  }
+  try {
+    await webpush.sendNotification(
+      subscription,
+      JSON.stringify({
+        title: 'New Blog Published',
+        body: message,
+        icon: '/icon.png',
+      })
+    );
+    return { success: true };
+  } catch (error) {
+    console.error('Error sending push notification:', error);
+    return { success: false, error: 'Failed to send notification' };
+  }
+}

--- a/blogScheduler.js
+++ b/blogScheduler.js
@@ -5,6 +5,7 @@
 import mongoose from 'mongoose';
 import Blog from './app/models/Blog.js';
 import dotenv from 'dotenv';
+import { sendNotification } from './app/pushActions.js';
 
 dotenv.config({ path: '.env.local' });
 
@@ -30,6 +31,11 @@ async function publishScheduledBlogs() {
     blog.status = 2; // Change status to published
     await blog.save();
     console.log(`Published blog: ${blog.title} (${blog._id})`);
+    try {
+      await sendNotification(`New blog published: ${blog.title}`);
+    } catch (err) {
+      console.error('Failed to send notification', err);
+    }
   }
 }
 

--- a/components/push/InstallPrompt.jsx
+++ b/components/push/InstallPrompt.jsx
@@ -1,0 +1,31 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+export default function InstallPrompt() {
+  const [isIOS, setIsIOS] = useState(false)
+  const [isStandalone, setIsStandalone] = useState(false)
+
+  useEffect(() => {
+    setIsIOS(/iPad|iPhone|iPod/.test(navigator.userAgent) && !(window.MSStream))
+    setIsStandalone(window.matchMedia('(display-mode: standalone)').matches)
+  }, [])
+
+  if (isStandalone) {
+    return null
+  }
+
+  return (
+    <div>
+      <h3>Install App</h3>
+      <button>Add to Home Screen</button>
+      {isIOS && (
+        <p>
+          To install this app on your iOS device, tap the share button
+          <span role="img" aria-label="share icon"> ⎋ </span>
+          and then "Add to Home Screen"
+          <span role="img" aria-label="plus icon"> ➕ </span>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/push/PushNotificationManager.jsx
+++ b/components/push/PushNotificationManager.jsx
@@ -48,8 +48,8 @@ export default function PushNotificationManager() {
 
   async function unsubscribeFromPush() {
     await subscription?.unsubscribe()
+    await unsubscribeUser(subscription)
     setSubscription(null)
-    await unsubscribeUser()
   }
 
   async function sendTestNotification() {

--- a/components/push/PushNotificationManager.jsx
+++ b/components/push/PushNotificationManager.jsx
@@ -1,0 +1,89 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { subscribeUser, unsubscribeUser, sendNotification } from '@/app/pushActions'
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = window.atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}
+
+export default function PushNotificationManager() {
+  const [isSupported, setIsSupported] = useState(false)
+  const [subscription, setSubscription] = useState(null)
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    if ('serviceWorker' in navigator && 'PushManager' in window) {
+      setIsSupported(true)
+      registerServiceWorker()
+    }
+  }, [])
+
+  async function registerServiceWorker() {
+    const registration = await navigator.serviceWorker.register('/sw.js', {
+      scope: '/',
+      updateViaCache: 'none',
+    })
+    const sub = await registration.pushManager.getSubscription()
+    setSubscription(sub)
+  }
+
+  async function subscribeToPush() {
+    const registration = await navigator.serviceWorker.ready
+    const sub = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(
+        process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+      ),
+    })
+    setSubscription(sub)
+    await subscribeUser(sub)
+  }
+
+  async function unsubscribeFromPush() {
+    await subscription?.unsubscribe()
+    setSubscription(null)
+    await unsubscribeUser()
+  }
+
+  async function sendTestNotification() {
+    if (subscription) {
+      await sendNotification(message)
+      setMessage('')
+    }
+  }
+
+  if (!isSupported) {
+    return <p>Push notifications are not supported in this browser.</p>
+  }
+
+  return (
+    <div>
+      <h3>Push Notifications</h3>
+      {subscription ? (
+        <>
+          <p>You are subscribed to push notifications.</p>
+          <button onClick={unsubscribeFromPush}>Unsubscribe</button>
+          <input
+            type="text"
+            placeholder="Enter notification message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+          <button onClick={sendTestNotification}>Send Test</button>
+        </>
+      ) : (
+        <>
+          <p>You are not subscribed to push notifications.</p>
+          <button onClick={subscribeToPush}>Subscribe</button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,6 +28,26 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
+      {
+        source: '/sw.js',
+        headers: [
+          { key: 'Content-Type', value: 'application/javascript; charset=utf-8' },
+          { key: 'Cache-Control', value: 'no-cache, no-store, must-revalidate' },
+          { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self'" },
+        ],
+      },
+    ]
+  },
   experimental: {
     // inlineCss: true,
     // optimizePackageImports: ['swiper'],

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lucide-react": "^0.513.0",
     "moment": "^2.30.1",
     "mongoose": "^8.16.0",
-    "next": "^15.3.3",
+    "next": "^15.3.4",
     "node-fetch": "^3.3.2",
     "nodemailer": "^7.0.3",
     "qrcode": "^1.5.4",
@@ -72,7 +72,8 @@
     "tailwind-merge": "^3.3.0",
     "tinymce": "^7.9.1",
     "zod": "^3.25.64",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -80,7 +81,7 @@
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.2.0",
     "eslint": "^9",
-    "eslint-config-next": "15.3.3",
+    "eslint-config-next": "15.3.4",
     "eslint-config-prettier": "^10.1.5",
     "postcss": "^8.5.4",
     "prettier": "^3.5.3",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,22 @@
+self.addEventListener('push', function (event) {
+  if (event.data) {
+    const data = event.data.json();
+    const options = {
+      body: data.body,
+      icon: data.icon || '/icon.png',
+      badge: '/badge.png',
+      vibrate: [100, 50, 100],
+      data: {
+        dateOfArrival: Date.now(),
+        primaryKey: '2',
+      },
+    };
+    event.waitUntil(self.registration.showNotification(data.title, options));
+  }
+});
+
+self.addEventListener('notificationclick', function (event) {
+  console.log('Notification click received.');
+  event.notification.close();
+  event.waitUntil(clients.openWindow('https://your-website.com'));
+});


### PR DESCRIPTION
## Summary
- set up basic web push functionality with `web-push`
- add service worker for push events
- implement push notification manager and install prompt components
- integrate push subscription UI on the frontend home page
- trigger push notifications when blogs are published
- schedule script also sends notifications
- apply security headers for PWA support
- document env vars
- update dependencies to Next.js 15.3.4

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866151531d88328baf6c86f44581bde