### PR TITLE
Improve admin login persistence

### DIFF
--- a/app/(auth)/login/loginForm.jsx
+++ b/app/(auth)/login/loginForm.jsx
@@ -64,13 +64,14 @@ export function LoginForm() {
             const data = await response.json();
 
             if (data?.success) {
-                document.cookie = `token=${data?.token}; path=/; priority=high;`;
-                document.cookie = `userEmail=${data?.data?.email}; path=/;`;
-                document.cookie = `userRole=${data?.data?.role}; path=/;`;
+                const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+                document.cookie = `token=${data?.token}; path=/; max-age=${COOKIE_MAX_AGE}; priority=high;`;
+                document.cookie = `userEmail=${data?.data?.email}; path=/; max-age=${COOKIE_MAX_AGE}`;
+                document.cookie = `userRole=${data?.data?.role}; path=/; max-age=${COOKIE_MAX_AGE}`;
                 const permStr = btoa(JSON.stringify(data?.data?.permissions || {}));
-                document.cookie = `userPermissions=${permStr}; path=/;`;
+                document.cookie = `userPermissions=${permStr}; path=/; max-age=${COOKIE_MAX_AGE}`;
                 if (data?.data?.permissionsUpdatedAt) {
-                    document.cookie = `permissionsStamp=${data.data.permissionsUpdatedAt}; path=/;`;
+                    document.cookie = `permissionsStamp=${data.data.permissionsUpdatedAt}; path=/; max-age=${COOKIE_MAX_AGE}`;
                 }
 
                 toast.success(data.message);

--- a/app/actions/admin.js
+++ b/app/actions/admin.js
@@ -84,7 +84,7 @@ export async function registerAdmin(formData, req) {
     const token = jwt.sign(
       { id: admin._id, email: admin.email, role: admin.role },
       process.env.JWT_SECRET || 'your-secret-key',
-      { expiresIn: '24h' }
+      { expiresIn: '30d' }
     );
 
     // Remove sensitive data
@@ -197,7 +197,7 @@ export async function loginAdmin(email, password) {
         twoFactorVerified: false 
       },
       process.env.JWT_SECRET || 'your-secret-key',
-      { expiresIn: '24h' }
+      { expiresIn: '30d' }
     );
 
     // Remove sensitive data from response

--- a/app/api/v1/admin/(auth)/2fa/verify/route.js
+++ b/app/api/v1/admin/(auth)/2fa/verify/route.js
@@ -54,7 +54,7 @@ export async function POST(req) {
         twoFactorVerified: true 
       },
       process.env.JWT_SECRET || 'your-secret-key',
-      { expiresIn: '24h' }
+      { expiresIn: '30d' }
     );
 
     return NextResponse.json({

--- a/app/lib/auth.js
+++ b/app/lib/auth.js
@@ -20,7 +20,7 @@ export function verifyToken(token) {
  * @param {string} expiresIn - Token expiration time
  * @returns {string} - Generated JWT token
  */
-export function generateToken(payload, expiresIn = '24h') {
+export function generateToken(payload, expiresIn = '30d') {
   return jwt.sign(payload, process.env.JWT_SECRET || 'your-secret-key', { expiresIn });
 }
 


### PR DESCRIPTION
## Summary
- keep login tokens valid for 30 days
- persist auth cookies for 30 days

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686756500a9c83288d3a5331b214d0a9