### PR TITLE
Improve admin login persistence

### DIFF
--- a/app/(auth)/login/loginForm.jsx
+++ b/app/(auth)/login/loginForm.jsx
@@ -7,7 +7,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import useErrorHandler from "@/helpers/errors"
-import { setCookie } from "cookies-next"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -65,22 +64,6 @@ export function LoginForm() {
             const data = await response.json();
 
             if (data?.success) {
-                const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
-                const options = {
-                    maxAge: COOKIE_MAX_AGE,
-                    path: '/',
-                    sameSite: 'lax',
-                    expires: new Date(Date.now() + COOKIE_MAX_AGE * 1000)
-                };
-                setCookie('token', data?.token, options);
-                setCookie('userEmail', data?.data?.email, options);
-                setCookie('userRole', data?.data?.role, options);
-                const permStr = btoa(JSON.stringify(data?.data?.permissions || {}));
-                setCookie('userPermissions', permStr, options);
-                if (data?.data?.permissionsUpdatedAt) {
-                    setCookie('permissionsStamp', data.data.permissionsUpdatedAt, options);
-                }
-
                 toast.success(data.message);
 
                 // get redirectTo from query params if present

--- a/app/(auth)/login/loginForm.jsx
+++ b/app/(auth)/login/loginForm.jsx
@@ -7,6 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import useErrorHandler from "@/helpers/errors"
+import { setCookie } from "cookies-next"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -64,13 +65,20 @@ export function LoginForm() {
             const data = await response.json();
 
             if (data?.success) {
-                document.cookie = `token=${data?.token}; path=/; priority=high;`;
-                document.cookie = `userEmail=${data?.data?.email}; path=/;`;
-                document.cookie = `userRole=${data?.data?.role}; path=/;`;
+                const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+                const options = {
+                    maxAge: COOKIE_MAX_AGE,
+                    path: '/',
+                    sameSite: 'lax',
+                    expires: new Date(Date.now() + COOKIE_MAX_AGE * 1000)
+                };
+                setCookie('token', data?.token, options);
+                setCookie('userEmail', data?.data?.email, options);
+                setCookie('userRole', data?.data?.role, options);
                 const permStr = btoa(JSON.stringify(data?.data?.permissions || {}));
-                document.cookie = `userPermissions=${permStr}; path=/;`;
+                setCookie('userPermissions', permStr, options);
                 if (data?.data?.permissionsUpdatedAt) {
-                    document.cookie = `permissionsStamp=${data.data.permissionsUpdatedAt}; path=/;`;
+                    setCookie('permissionsStamp', data.data.permissionsUpdatedAt, options);
                 }
 
                 toast.success(data.message);

--- a/app/actions/admin.js
+++ b/app/actions/admin.js
@@ -84,7 +84,7 @@ export async function registerAdmin(formData, req) {
     const token = jwt.sign(
       { id: admin._id, email: admin.email, role: admin.role },
       process.env.JWT_SECRET || 'your-secret-key',
-      { expiresIn: '24h' }
+      { expiresIn: '30d' }
     );
 
     // Remove sensitive data
@@ -197,7 +197,7 @@ export async function loginAdmin(email, password) {
         twoFactorVerified: false 
       },
       process.env.JWT_SECRET || 'your-secret-key',
-      { expiresIn: '24h' }
+      { expiresIn: '30d' }
     );
 
     // Remove sensitive data from response

--- a/app/api/v1/admin/(auth)/2fa/verify/route.js
+++ b/app/api/v1/admin/(auth)/2fa/verify/route.js
@@ -64,7 +64,14 @@ export async function POST(req) {
     };
     const response = NextResponse.json(json);
     const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
-    const options = { maxAge: COOKIE_MAX_AGE, path: '/' };
+    const options = {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      maxAge: COOKIE_MAX_AGE,
+      expires: new Date(Date.now() + COOKIE_MAX_AGE * 1000),
+      path: '/'
+    };
     response.cookies.set('token', jwtToken, options);
     response.cookies.set('userEmail', admin.email, options);
     response.cookies.set('userRole', admin.role, options);

--- a/app/api/v1/admin/(auth)/2fa/verify/route.js
+++ b/app/api/v1/admin/(auth)/2fa/verify/route.js
@@ -54,14 +54,26 @@ export async function POST(req) {
         twoFactorVerified: true 
       },
       process.env.JWT_SECRET || 'your-secret-key',
-      { expiresIn: '24h' }
+      { expiresIn: '30d' }
     );
 
-    return NextResponse.json({
+    const json = {
       success: true,
       message: '2FA verification successful',
       token: jwtToken
-    });
+    };
+    const response = NextResponse.json(json);
+    const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+    const options = { maxAge: COOKIE_MAX_AGE, path: '/' };
+    response.cookies.set('token', jwtToken, options);
+    response.cookies.set('userEmail', admin.email, options);
+    response.cookies.set('userRole', admin.role, options);
+    const permStr = Buffer.from(JSON.stringify(admin.permissions || {})).toString('base64');
+    response.cookies.set('userPermissions', permStr, options);
+    if (admin.permissionsUpdatedAt) {
+      response.cookies.set('permissionsStamp', admin.permissionsUpdatedAt.toISOString(), options);
+    }
+    return response;
 
   } catch (error) {
     return NextResponse.json(

--- a/app/api/v1/admin/(auth)/login/route.js
+++ b/app/api/v1/admin/(auth)/login/route.js
@@ -50,7 +50,14 @@ async function handler(req, ip, failedLoginAttempts, lockoutDuration, failedAtte
   };
   const response = NextResponse.json(json, { status: 200 });
   const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
-  const options = { maxAge: COOKIE_MAX_AGE, path: '/' };
+  const options = {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    maxAge: COOKIE_MAX_AGE,
+    expires: new Date(Date.now() + COOKIE_MAX_AGE * 1000),
+    path: '/'
+  };
   response.cookies.set('token', result.token, options);
   response.cookies.set('userEmail', result.data.email, options);
   response.cookies.set('userRole', result.data.role, options);

--- a/app/api/v1/admin/(auth)/login/route.js
+++ b/app/api/v1/admin/(auth)/login/route.js
@@ -42,15 +42,24 @@ async function handler(req, ip, failedLoginAttempts, lockoutDuration, failedAtte
   // Clear failed login attempts on successful login
   failedLoginAttempts.delete(ip);
 
-  return NextResponse.json(
-    {
-      success: true,
-      message: 'Login successful',
-      data: result.data,
-      token: result.token
-    },
-    { status: 200 }
-  );
+  const json = {
+    success: true,
+    message: 'Login successful',
+    data: result.data,
+    token: result.token
+  };
+  const response = NextResponse.json(json, { status: 200 });
+  const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+  const options = { maxAge: COOKIE_MAX_AGE, path: '/' };
+  response.cookies.set('token', result.token, options);
+  response.cookies.set('userEmail', result.data.email, options);
+  response.cookies.set('userRole', result.data.role, options);
+  const permStr = Buffer.from(JSON.stringify(result.data.permissions || {})).toString('base64');
+  response.cookies.set('userPermissions', permStr, options);
+  if (result.data.permissionsUpdatedAt) {
+    response.cookies.set('permissionsStamp', result.data.permissionsUpdatedAt, options);
+  }
+  return response;
 }
 
 export async function POST(req) {

--- a/app/lib/auth.js
+++ b/app/lib/auth.js
@@ -20,7 +20,7 @@ export function verifyToken(token) {
  * @param {string} expiresIn - Token expiration time
  * @returns {string} - Generated JWT token
  */
-export function generateToken(payload, expiresIn = '24h') {
+export function generateToken(payload, expiresIn = '30d') {
   return jwt.sign(payload, process.env.JWT_SECRET || 'your-secret-key', { expiresIn });
 }
 


### PR DESCRIPTION
## Summary
- keep login tokens valid for 30 days
- persist auth cookies from the server and client

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686756500a9c83288d3a5331b214d0a9