### PR TITLE
Add zustand profile store and skeletons

### DIFF
--- a/app/admin/profile/edit/loading.jsx
+++ b/app/admin/profile/edit/loading.jsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/profile/edit/page.jsx
+++ b/app/admin/profile/edit/page.jsx
@@ -4,9 +4,9 @@ import { useProfile } from "@/hooks/use-profile";
 import ProfileEditSkeleton from "@/components/skeleton/profile-edit-skeleton";
 
 export default function Page() {
-  const { profile: admin } = useProfile();
+  const { profile: admin, loading } = useProfile();
 
-  if (admin === undefined) {
+  if (loading) {
     return <ProfileEditSkeleton />;
   }
 

--- a/app/admin/profile/edit/page.jsx
+++ b/app/admin/profile/edit/page.jsx
@@ -1,22 +1,24 @@
+"use client";
 import EditAdminForm from "../../admins/[id]/edit/EditAdminForm";
-import { cookies } from "next/headers";
+import { useProfile } from "@/hooks/use-profile";
+import ProfileEditSkeleton from "@/components/skeleton/profile-edit-skeleton";
 
-export default async function Page() {
-  const store = await cookies();
-  const token = store.get("token")?.value || "";
-  const base = process.env.NEXT_PUBLIC_BASE_URL || "";
-  const res = await fetch(`${base}/api/v1/admin/admins/me`, {
-    cache: "no-store",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await res.json();
-  const admin = json?.data;
-  if (!admin) return <div className="p-4">Admin not found</div>;
+export default function Page() {
+  const { profile: admin } = useProfile();
+
+  if (admin === undefined) {
+    return <ProfileEditSkeleton />;
+  }
+
+  if (admin === null) {
+    return <div className="p-4">Admin not found</div>;
+  }
+
   return (
     <div className="w-full p-4">
       <EditAdminForm
         admin={admin}
-        hideDepartment={admin.role === 'superadmin'}
+        hideDepartment={admin.role === "superadmin"}
         redirectTo="/admin/profile"
       />
     </div>

--- a/app/admin/profile/loading.jsx
+++ b/app/admin/profile/loading.jsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="w-full p-4 flex flex-col items-center gap-4">
+      <Skeleton className="h-[120px] w-[120px] rounded-full" />
+      <Skeleton className="h-6 w-40" />
+      <Skeleton className="h-4 w-48" />
+      <Skeleton className="h-10 w-32" />
+    </div>
+  );
+}

--- a/app/admin/profile/page.jsx
+++ b/app/admin/profile/page.jsx
@@ -6,9 +6,9 @@ import ProfileSkeleton from "@/components/skeleton/profile-skeleton";
 import { useProfile } from "@/hooks/use-profile";
 
 export default function Page() {
-  const { profile: admin } = useProfile();
+  const { profile: admin, loading } = useProfile();
 
-  if (admin === undefined) {
+  if (loading) {
     return <ProfileSkeleton />;
   }
 

--- a/app/admin/profile/page.jsx
+++ b/app/admin/profile/page.jsx
@@ -1,29 +1,38 @@
+"use client";
 import Image from "next/image";
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { Button } from "@/components/ui/button";
+import ProfileSkeleton from "@/components/skeleton/profile-skeleton";
+import { useProfile } from "@/hooks/use-profile";
 
-export default async function Page() {
-  const store = await cookies();
-  const token = store.get("token")?.value || "";
-  const base = process.env.NEXT_PUBLIC_BASE_URL || "";
-  const res = await fetch(`${base}/api/v1/admin/admins/me`, {
-    cache: "no-store",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await res.json();
-  const admin = json?.data;
-  if (!admin) return <div className="p-4">Admin not found</div>;
+export default function Page() {
+  const { profile: admin } = useProfile();
+
+  if (admin === undefined) {
+    return <ProfileSkeleton />;
+  }
+
+  if (admin === null) {
+    return <div className="p-4">Admin not found</div>;
+  }
+
   const imageSrc = admin.profileImage
     ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/admins/${admin.profileImage}?t=${Date.now()}`
     : null;
-  const name = admin.firstName || admin.lastName
-    ? `${admin.firstName || ""} ${admin.lastName || ""}`.trim()
-    : admin.username || admin.email;
+  const name =
+    admin.firstName || admin.lastName
+      ? `${admin.firstName || ""} ${admin.lastName || ""}`.trim()
+      : admin.username || admin.email;
   return (
     <div className="w-full p-4 flex flex-col items-center gap-4">
       {imageSrc && (
-        <Image src={imageSrc} alt={name} width={120} height={120} className="rounded-full object-cover" />
+        <Image
+          src={imageSrc}
+          alt={name}
+          width={120}
+          height={120}
+          className="rounded-full object-cover"
+        />
       )}
       <h2 className="text-xl font-bold">{name || "No Name"}</h2>
       <p className="text-sm text-muted-foreground">{admin.email}</p>

--- a/app/store/use-profile-store.js
+++ b/app/store/use-profile-store.js
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+export const useProfileStore = create((set) => ({
+  profile: null,
+  setProfile: (profile) => set({ profile }),
+  updateProfile: (updates) =>
+    set((state) => ({
+      profile: state.profile ? { ...state.profile, ...updates } : state.profile,
+    })),
+  clearProfile: () => set({ profile: null }),
+}));

--- a/components/nav-user.jsx
+++ b/components/nav-user.jsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import * as React from "react";
 
@@ -9,13 +9,9 @@ import {
   Settings2,
   Users,
   UserPlus,
-} from "lucide-react"
+} from "lucide-react";
 
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/components/ui/avatar"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,71 +20,82 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+} from "@/components/ui/dropdown-menu";
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
   useSidebar,
-} from "@/components/ui/sidebar"
-import { getCookie } from "cookies-next"
-import Link from "next/link"
-import { useRouter } from "next/navigation"
-import { toast } from "sonner"
+} from "@/components/ui/sidebar";
+import { getCookie } from "cookies-next";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useProfile } from "@/hooks/use-profile";
+import { NavUserSkeleton } from "@/components/skeleton/nav-user-skeleton";
 
 export function NavUser() {
-  const { isMobile } = useSidebar()
-  const [profile, setProfile] = React.useState({ name: '', email: '', avatar: null, initials: '' })
-  React.useEffect(() => {
-    async function load() {
-      try {
-        const token = getCookie('token');
-        const headers = token ? { Authorization: `Bearer ${token}` } : {};
-        const res = await fetch('/api/v1/admin/admins/me', { cache: 'no-store', headers });
-        const json = await res.json();
-        if (json.success) {
-          const d = json.data;
-          const name = d.firstName || d.lastName
-            ? `${d.firstName || ''} ${d.lastName || ''}`.trim()
-            : d.username || d.email;
-          const avatar = d.profileImage
-            ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/admins/${d.profileImage}`
-            : null;
-          const initials = `${d.firstName?.[0] || ''}${d.lastName?.[0] || ''}`.toUpperCase();
-          setProfile({ name, email: d.email, avatar, initials });
-        }
-      } catch {}
-    }
-    load();
-  }, []);
+  const { isMobile } = useSidebar();
+  const { profile: admin, loading } = useProfile();
+  const profile = React.useMemo(() => {
+    if (!admin) return { name: "", email: "", avatar: null, initials: "" };
+    const name =
+      admin.firstName || admin.lastName
+        ? `${admin.firstName || ""} ${admin.lastName || ""}`.trim()
+        : admin.username || admin.email;
+    const avatar = admin.profileImage
+      ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/admins/${admin.profileImage}`
+      : null;
+    const initials =
+      `${admin.firstName?.[0] || ""}${admin.lastName?.[0] || ""}`.toUpperCase();
+    return { name, email: admin.email, avatar, initials };
+  }, [admin]);
 
-      const router = useRouter();
-  
-      const handleLogout = async () => {
-          try {
-              await fetch("/api/v1/admin/logout");
-              document.cookie = "userPermissions=; max-age=0; path=/;";
-              toast.success("Logged out");
-              router.push("/login");
-          } catch (error) {
-              toast.error("Failed to logout");
-          }
-      };
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      await fetch("/api/v1/admin/logout");
+      document.cookie = "userPermissions=; max-age=0; path=/;";
+      toast.success("Logged out");
+      router.push("/login");
+    } catch (error) {
+      toast.error("Failed to logout");
+    }
+  };
+
+  if (loading) {
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <NavUserSkeleton />
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+  }
 
   return (
-    (<SidebarMenu>
+    <SidebarMenu>
       <SidebarMenuItem>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground">
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
               <Avatar className="h-8 w-8 rounded-lg">
-                <AvatarImage src={profile.avatar || undefined} alt={profile.name} />
-                <AvatarFallback className="rounded-lg">{profile.initials || (profile.name?.[0] || 'U')}</AvatarFallback>
+                <AvatarImage
+                  src={profile.avatar || undefined}
+                  alt={profile.name}
+                />
+                <AvatarFallback className="rounded-lg">
+                  {profile.initials || profile.name?.[0] || "U"}
+                </AvatarFallback>
               </Avatar>
               <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium">{profile.name || 'User'}</span>
+                <span className="truncate font-medium">
+                  {profile.name || "User"}
+                </span>
                 <span className="truncate text-xs">{profile.email}</span>
               </div>
               <ChevronsUpDown className="ml-auto size-4" />
@@ -98,15 +105,23 @@ export function NavUser() {
             className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
             side={isMobile ? "bottom" : "right"}
             align="end"
-            sideOffset={4}>
+            sideOffset={4}
+          >
             <DropdownMenuLabel className="p-0 font-normal">
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
-                  <AvatarImage src={profile.avatar || undefined} alt={profile.name} />
-                  <AvatarFallback className="rounded-lg">{profile.initials || (profile.name?.[0] || 'U')}</AvatarFallback>
+                  <AvatarImage
+                    src={profile.avatar || undefined}
+                    alt={profile.name}
+                  />
+                  <AvatarFallback className="rounded-lg">
+                    {profile.initials || profile.name?.[0] || "U"}
+                  </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-medium">{profile.name || 'User'}</span>
+                  <span className="truncate font-medium">
+                    {profile.name || "User"}
+                  </span>
                   <span className="truncate text-xs">{profile.email}</span>
                 </div>
               </div>
@@ -122,11 +137,14 @@ export function NavUser() {
                 <Settings2 />
                 Setting
               </DropdownMenuItem>
-              {getCookie('userRole') === 'superadmin' && (
+              {getCookie("userRole") === "superadmin" && (
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
-                    <Link href="/admin/admins" className="flex items-center gap-2">
+                    <Link
+                      href="/admin/admins"
+                      className="flex items-center gap-2"
+                    >
                       <Users className="h-4 w-4" /> All Admins
                     </Link>
                   </DropdownMenuItem>
@@ -141,6 +159,6 @@ export function NavUser() {
           </DropdownMenuContent>
         </DropdownMenu>
       </SidebarMenuItem>
-    </SidebarMenu>)
+    </SidebarMenu>
   );
 }

--- a/components/skeleton/nav-user-skeleton.jsx
+++ b/components/skeleton/nav-user-skeleton.jsx
@@ -1,13 +1,14 @@
-"use client"
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export function NavUserSkeleton() {
   return (
     <div className="flex items-center gap-2 p-4">
-      <div className="h-8 w-8 animate-pulse rounded-full bg-black/10" />
+      <Skeleton className="h-8 w-8 rounded-full" />
       <div className="space-y-1">
-        <div className="h-4 w-20 animate-pulse rounded bg-black/10" />
-        <div className="h-3 w-28 animate-pulse rounded bg-black/10" />
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-3 w-28" />
       </div>
     </div>
-  )
+  );
 }

--- a/components/skeleton/profile-edit-skeleton.jsx
+++ b/components/skeleton/profile-edit-skeleton.jsx
@@ -1,0 +1,47 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function ProfileEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/skeleton/profile-skeleton.jsx
+++ b/components/skeleton/profile-skeleton.jsx
@@ -1,0 +1,13 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ProfileSkeleton() {
+  return (
+    <div className="w-full p-4 flex flex-col items-center gap-4">
+      <Skeleton className="h-[120px] w-[120px] rounded-full" />
+      <Skeleton className="h-6 w-40" />
+      <Skeleton className="h-4 w-48" />
+      <Skeleton className="h-10 w-32" />
+    </div>
+  );
+}

--- a/hooks/use-profile.js
+++ b/hooks/use-profile.js
@@ -1,0 +1,28 @@
+import { useEffect, useState, useCallback } from "react";
+import apiFetch from "@/helpers/apiFetch";
+import { useProfileStore } from "@/app/store/use-profile-store";
+
+export function useProfile() {
+  const profile = useProfileStore((state) => state.profile);
+  const setProfile = useProfileStore((state) => state.setProfile);
+  const clearProfile = useProfileStore((state) => state.clearProfile);
+  const [loading, setLoading] = useState(!profile);
+
+  const refresh = useCallback(() => {
+    clearProfile();
+  }, [clearProfile]);
+
+  useEffect(() => {
+    if (!profile) {
+      setLoading(true);
+      apiFetch("/api/v1/admin/admins/me")
+        .then((res) => res.json())
+        .then((json) => {
+          setProfile(json?.data ?? null);
+        })
+        .finally(() => setLoading(false));
+    }
+  }, [profile, setProfile]);
+
+  return { profile, loading, refresh };
+}


### PR DESCRIPTION
## Summary
- manage admin profile data with zustand
- add custom hook for admin profile
- convert profile pages to client components using the new hook
- show loading skeletons for profile pages

## Testing
- `npx prettier -w app/admin/profile/page.jsx app/admin/profile/edit/page.jsx app/admin/profile/loading.jsx app/admin/profile/edit/loading.jsx components/skeleton/profile-skeleton.jsx components/skeleton/profile-edit-skeleton.jsx hooks/use-profile.js app/store/use-profile-store.js`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867697393588328942c64d30b2df329