### PR TITLE
Add profile zustand store and skeletons

### DIFF
--- a/app/admin/profile/edit/loading.jsx
+++ b/app/admin/profile/edit/loading.jsx
@@ -1,0 +1,5 @@
+import ProfileEditSkeleton from "@/components/skeleton/profile-edit-skeleton";
+
+export default function Loading() {
+  return <ProfileEditSkeleton />;
+}

--- a/app/admin/profile/edit/page.jsx
+++ b/app/admin/profile/edit/page.jsx
@@ -1,22 +1,24 @@
+"use client";
 import EditAdminForm from "../../admins/[id]/edit/EditAdminForm";
-import { cookies } from "next/headers";
+import { useProfile } from "@/hooks/use-profile";
+import ProfileEditSkeleton from "@/components/skeleton/profile-edit-skeleton";
 
-export default async function Page() {
-  const store = await cookies();
-  const token = store.get("token")?.value || "";
-  const base = process.env.NEXT_PUBLIC_BASE_URL || "";
-  const res = await fetch(`${base}/api/v1/admin/admins/me`, {
-    cache: "no-store",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await res.json();
-  const admin = json?.data;
-  if (!admin) return <div className="p-4">Admin not found</div>;
+export default function Page() {
+  const { profile } = useProfile();
+
+  if (profile === undefined) {
+    return <ProfileEditSkeleton />;
+  }
+
+  if (profile === null) {
+    return <div className="p-4">Admin not found</div>;
+  }
+
   return (
     <div className="w-full p-4">
       <EditAdminForm
-        admin={admin}
-        hideDepartment={admin.role === 'superadmin'}
+        admin={profile}
+        hideDepartment={profile.role === 'superadmin'}
         redirectTo="/admin/profile"
       />
     </div>

--- a/app/admin/profile/loading.jsx
+++ b/app/admin/profile/loading.jsx
@@ -1,0 +1,5 @@
+import ProfileDetailSkeleton from "@/components/skeleton/profile-detail-skeleton";
+
+export default function Loading() {
+  return <ProfileDetailSkeleton />;
+}

--- a/app/admin/profile/page.jsx
+++ b/app/admin/profile/page.jsx
@@ -1,32 +1,35 @@
+"use client";
 import Image from "next/image";
 import Link from "next/link";
-import { cookies } from "next/headers";
 import { Button } from "@/components/ui/button";
+import { useProfile } from "@/hooks/use-profile";
+import ProfileDetailSkeleton from "@/components/skeleton/profile-detail-skeleton";
 
-export default async function Page() {
-  const store = await cookies();
-  const token = store.get("token")?.value || "";
-  const base = process.env.NEXT_PUBLIC_BASE_URL || "";
-  const res = await fetch(`${base}/api/v1/admin/admins/me`, {
-    cache: "no-store",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const json = await res.json();
-  const admin = json?.data;
-  if (!admin) return <div className="p-4">Admin not found</div>;
-  const imageSrc = admin.profileImage
-    ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/admins/${admin.profileImage}?t=${Date.now()}`
+export default function Page() {
+  const { profile } = useProfile();
+
+  if (profile === undefined) {
+    return <ProfileDetailSkeleton />;
+  }
+
+  if (profile === null) {
+    return <div className="p-4">Admin not found</div>;
+  }
+
+  const imageSrc = profile.profileImage
+    ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/admins/${profile.profileImage}?t=${Date.now()}`
     : null;
-  const name = admin.firstName || admin.lastName
-    ? `${admin.firstName || ""} ${admin.lastName || ""}`.trim()
-    : admin.username || admin.email;
+  const name = profile.firstName || profile.lastName
+    ? `${profile.firstName || ""} ${profile.lastName || ""}`.trim()
+    : profile.username || profile.email;
+
   return (
     <div className="w-full p-4 flex flex-col items-center gap-4">
       {imageSrc && (
         <Image src={imageSrc} alt={name} width={120} height={120} className="rounded-full object-cover" />
       )}
       <h2 className="text-xl font-bold">{name || "No Name"}</h2>
-      <p className="text-sm text-muted-foreground">{admin.email}</p>
+      <p className="text-sm text-muted-foreground">{profile.email}</p>
       <Link href="/admin/profile/edit">
         <Button type="button">Edit Profile</Button>
       </Link>

--- a/app/store/use-profile-store.js
+++ b/app/store/use-profile-store.js
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+export const useProfileStore = create((set) => ({
+  profile: undefined,
+  setProfile: (profile) => set({ profile }),
+  updateProfile: (updates) =>
+    set((state) => ({
+      profile: state.profile ? { ...state.profile, ...updates } : state.profile,
+    })),
+  clearProfile: () => set({ profile: undefined }),
+}))

--- a/components/skeleton/profile-detail-skeleton.jsx
+++ b/components/skeleton/profile-detail-skeleton.jsx
@@ -1,0 +1,13 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ProfileDetailSkeleton() {
+  return (
+    <div className="w-full p-4 flex flex-col items-center gap-4">
+      <Skeleton className="h-[120px] w-[120px] rounded-full" />
+      <Skeleton className="h-6 w-40" />
+      <Skeleton className="h-4 w-56" />
+      <Skeleton className="h-10 w-32" />
+    </div>
+  );
+}

--- a/components/skeleton/profile-edit-skeleton.jsx
+++ b/components/skeleton/profile-edit-skeleton.jsx
@@ -1,0 +1,33 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function ProfileEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-64" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/hooks/use-profile.js
+++ b/hooks/use-profile.js
@@ -1,0 +1,28 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useProfileStore } from '@/app/store/use-profile-store'
+
+export function useProfile() {
+  const profile = useProfileStore((state) => state.profile)
+  const setProfile = useProfileStore((state) => state.setProfile)
+  const clearProfile = useProfileStore((state) => state.clearProfile)
+  const [loading, setLoading] = useState(profile === undefined)
+
+  const refresh = useCallback(() => {
+    clearProfile()
+  }, [clearProfile])
+
+  useEffect(() => {
+    if (profile === undefined) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/admins/me')
+        .then((res) => res.json())
+        .then((json) => {
+          setProfile(json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [profile, setProfile])
+
+  return { profile, loading, refresh }
+}


### PR DESCRIPTION
## Summary
- use zustand store for admin profile info
- add hook `useProfile` to load current admin data
- create profile detail and edit skeleton components
- show skeletons in profile pages with loading components

## Testing
- `npx next lint` *(fails: needs next install)*

------
https://chatgpt.com/codex/tasks/task_e_68676f53d1d08328aeaafdb51d1ea75c