### PR TITLE
Add zustand support and skeletons for schema pages

### DIFF
--- a/app/admin/schema/[slug]/add/loading.jsx
+++ b/app/admin/schema/[slug]/add/loading.jsx
@@ -1,0 +1,5 @@
+import SchemaAddSkeleton from '@/components/skeleton/schema-add-skeleton'
+
+export default function Loading() {
+  return <SchemaAddSkeleton />
+}

--- a/app/admin/schema/loading.jsx
+++ b/app/admin/schema/loading.jsx
@@ -1,0 +1,5 @@
+import SchemaPageTableSkeleton from '@/components/skeleton/schema-page-table-skeleton'
+
+export default function Loading() {
+  return <SchemaPageTableSkeleton />
+}

--- a/app/admin/schema/page.jsx
+++ b/app/admin/schema/page.jsx
@@ -1,13 +1,15 @@
+"use client";
 import { SchemaPageTable } from '@/components/schemaPageTable';
+import SchemaPageTableSkeleton from '@/components/skeleton/schema-page-table-skeleton';
+import { useSchemaPages } from '@/hooks/use-schemas';
 
-async function getPages() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/pages`, { cache: 'no-store' });
-  const json = await res.json();
-  return Array.isArray(json.data) ? json.data : [];
-}
+export default function Page() {
+  const { pages } = useSchemaPages();
 
-export default async function Page() {
-  const pages = await getPages();
+  if (!pages) {
+    return <SchemaPageTableSkeleton />;
+  }
+
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
       <SchemaPageTable data={pages} />

--- a/app/store/use-schema-store.js
+++ b/app/store/use-schema-store.js
@@ -1,0 +1,7 @@
+import { create } from 'zustand'
+
+export const useSchemaStore = create((set) => ({
+  pages: null,
+  setPages: (pages) => set({ pages }),
+  clearPages: () => set({ pages: null }),
+}))

--- a/components/skeleton/schema-add-skeleton.jsx
+++ b/components/skeleton/schema-add-skeleton.jsx
@@ -1,0 +1,22 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SchemaAddSkeleton() {
+  return (
+    <div className="w-full p-4 space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+      {[...Array(5)].map((_, i) => (
+        <div key={i} className="space-y-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ))}
+      <div className="flex justify-end pt-4">
+        <Skeleton className="h-10 w-32" />
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/schema-page-table-skeleton.jsx
+++ b/components/skeleton/schema-page-table-skeleton.jsx
@@ -1,0 +1,43 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function SchemaPageTableSkeleton() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex gap-3 items-center py-4">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-8 w-24 ml-auto" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="rounded-md border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {[...Array(4)].map((_, i) => (
+                <TableHead key={i}>
+                  <Skeleton className="h-4 w-full" />
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {[...Array(5)].map((_, row) => (
+              <TableRow key={row}>
+                {[...Array(4)].map((_, cell) => (
+                  <TableCell key={cell}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}

--- a/hooks/use-schemas.js
+++ b/hooks/use-schemas.js
@@ -1,0 +1,30 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useSchemaStore } from '@/app/store/use-schema-store'
+
+export function useSchemaPages() {
+  const pages = useSchemaStore((state) => state.pages)
+  const setPages = useSchemaStore((state) => state.setPages)
+  const clearPages = useSchemaStore((state) => state.clearPages)
+  const [loading, setLoading] = useState(!pages)
+
+  const refresh = useCallback(() => {
+    clearPages()
+  }, [clearPages])
+
+  useEffect(() => {
+    if (!pages) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/pages')
+        .then((res) => res.json())
+        .then((json) => {
+          if (Array.isArray(json?.data)) {
+            setPages(json.data)
+          }
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [pages, setPages])
+
+  return { pages, loading, refresh }
+}


### PR DESCRIPTION
## Summary
- add zustand store for schema pages
- add hook for loading pages list
- make schema page a client component using new hook
- add skeletons for schema table and add page
- add loading components for schema module

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68680c5bdda88328919601383df4014c