### PR TITLE
Add skeleton and store for static meta page

### DIFF
--- a/app/admin/meta/static/loading.jsx
+++ b/app/admin/meta/static/loading.jsx
@@ -1,0 +1,5 @@
+import StaticMetaEditSkeleton from '@/components/skeleton/static-meta-edit-skeleton'
+
+export default function Loading() {
+  return <StaticMetaEditSkeleton />
+}

--- a/app/admin/meta/static/page.jsx
+++ b/app/admin/meta/static/page.jsx
@@ -1,33 +1,42 @@
-import EditStaticMetaForm from './EditStaticMetaForm';
+"use client";
+import { useMemo } from "react";
+import EditStaticMetaForm from "./EditStaticMetaForm";
+import StaticMetaEditSkeleton from "@/components/skeleton/static-meta-edit-skeleton";
+import { useStaticMeta } from "@/hooks/use-static-meta";
 
-export default async function Page() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/static`, { cache: 'no-store' });
-  const json = await res.json();
-  const meta = json?.data || null;
+export default function Page() {
+  const { meta } = useStaticMeta();
 
-  const toUrl = (name) =>
-    name && !name.startsWith('http')
-      ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${name}`
-      : name;
-  if (meta) {
-    meta.appleWebApp.startupImage.mainImageUrl = toUrl(
-      meta.appleWebApp.startupImage.mainImageUrl
+  const processedMeta = useMemo(() => {
+    if (!meta) return meta;
+    const m = structuredClone(meta);
+    const toUrl = (name) =>
+      name && !name.startsWith("http")
+        ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${name}`
+        : name;
+    m.appleWebApp.startupImage.mainImageUrl = toUrl(
+      m.appleWebApp.startupImage.mainImageUrl
     );
-    meta.appleWebApp.startupImage.url = toUrl(meta.appleWebApp.startupImage.url);
-    meta.icons.icon = meta.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }));
-    meta.icons.shortcut = toUrl(meta.icons.shortcut);
-    meta.icons.apple = toUrl(meta.icons.apple);
-    meta.icons.other = meta.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }));
-    meta.twitter.images = meta.twitter.images.map(toUrl);
-    meta.openGraph.images = meta.openGraph.images.map((img) => ({
+    m.appleWebApp.startupImage.url = toUrl(m.appleWebApp.startupImage.url);
+    m.icons.icon = m.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }));
+    m.icons.shortcut = toUrl(m.icons.shortcut);
+    m.icons.apple = toUrl(m.icons.apple);
+    m.icons.other = m.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }));
+    m.twitter.images = m.twitter.images.map(toUrl);
+    m.openGraph.images = m.openGraph.images.map((img) => ({
       ...img,
       url: toUrl(img.url),
     }));
+    return m;
+  }, [meta]);
+
+  if (meta === undefined) {
+    return <StaticMetaEditSkeleton />;
   }
 
   return (
     <div className="w-full p-4">
-      <EditStaticMetaForm meta={meta} />
+      <EditStaticMetaForm meta={processedMeta} />
     </div>
   );
 }

--- a/app/store/use-static-meta-store.js
+++ b/app/store/use-static-meta-store.js
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+export const useStaticMetaStore = create((set) => ({
+  meta: undefined,
+  setMeta: (meta) => set({ meta }),
+  updateMeta: (updates) =>
+    set((state) => ({
+      meta: state.meta ? { ...state.meta, ...updates } : updates,
+    })),
+  clearMeta: () => set({ meta: undefined }),
+}))

--- a/components/skeleton/static-meta-edit-skeleton.jsx
+++ b/components/skeleton/static-meta-edit-skeleton.jsx
@@ -1,0 +1,48 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function StaticMetaEditSkeleton() {
+  return (
+    <div className="w-full p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-40" />
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[120px] w-full" />
+            </div>
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="grid md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              </div>
+            ))}
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-[200px] w-full" />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Skeleton className="h-10 w-32" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/hooks/use-static-meta.js
+++ b/hooks/use-static-meta.js
@@ -1,0 +1,28 @@
+import { useEffect, useState, useCallback } from 'react'
+import apiFetch from '@/helpers/apiFetch'
+import { useStaticMetaStore } from '@/app/store/use-static-meta-store'
+
+export function useStaticMeta() {
+  const meta = useStaticMetaStore((state) => state.meta)
+  const setMeta = useStaticMetaStore((state) => state.setMeta)
+  const clearMeta = useStaticMetaStore((state) => state.clearMeta)
+  const [loading, setLoading] = useState(meta === undefined)
+
+  const refresh = useCallback(() => {
+    clearMeta()
+  }, [clearMeta])
+
+  useEffect(() => {
+    if (meta === undefined) {
+      setLoading(true)
+      apiFetch('/api/v1/admin/meta/static')
+        .then((res) => res.json())
+        .then((json) => {
+          setMeta(json?.data ?? null)
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [meta, setMeta])
+
+  return { meta, loading, refresh }
+}


### PR DESCRIPTION
## Summary
- add zustand store and hooks for static meta
- add loading skeleton for static meta page
- refactor static meta page to use zustand and display skeleton

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d00874c48328bf448aec9091a05d