### PR TITLE
Implement dynamic meta fetching

### DIFF
--- a/app/(auth)/forgot-password/page.jsx
+++ b/app/(auth)/forgot-password/page.jsx
@@ -2,21 +2,13 @@ import Image from "next/image";
 import ForgotForm from "./forgotForm";
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import getDynamicMeta from "@/helpers/getDynamicMeta";
+
+export async function generateMetadata() {
+  return await getDynamicMeta("/forgot-password");
+}
 
 const title = 'Forgot Password';
-
-export const metadata = {
-  title,
-  description: 'Reset your password',
-  robots: {
-    index: true,
-    follow: true,
-  },
-  openGraph: {
-    title,
-    images: [`/api/og?title=${title}`],
-  },
-};
 
 const ForgotPasswordPage = () => {
   return (

--- a/app/(auth)/login/page.jsx
+++ b/app/(auth)/login/page.jsx
@@ -1,22 +1,13 @@
 import Image from "next/image";
 import LoginForm from "./loginForm";
-import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import getDynamicMeta from "@/helpers/getDynamicMeta";
+
+export async function generateMetadata() {
+  return await getDynamicMeta("/login");
+}
 
 const title = 'Login';
-
-export const metadata = {
-  title,
-  description: 'Login to your account',
-  robots: {
-    index: true,
-    follow: true,
-  },
-  openGraph: {
-    title,
-    images: [`/api/og?title=${title}`],
-  },
-};
 
 const page = () => {
   return (

--- a/app/(auth)/reset-password/page.jsx
+++ b/app/(auth)/reset-password/page.jsx
@@ -3,21 +3,13 @@ import ResetForm from "./resetForm";
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Suspense } from "react";
+import getDynamicMeta from "@/helpers/getDynamicMeta";
+
+export async function generateMetadata() {
+  return await getDynamicMeta("/reset-password");
+}
 
 const title = 'Reset Password';
-
-export const metadata = {
-  title,
-  description: 'Reset your password',
-  robots: {
-    index: true,
-    follow: true,
-  },
-  openGraph: {
-    title,
-    images: [`/api/og?title=${title}`],
-  },
-};
 
 const ResetPasswordPage = () => {
   return (

--- a/app/(frontend)/about-us.php/page.jsx
+++ b/app/(frontend)/about-us.php/page.jsx
@@ -1,58 +1,10 @@
 import Image from "next/image";
 import Link from "next/link";
+import getDynamicMeta from "@/helpers/getDynamicMeta";
 
-export const metadata = {
-        title: "About IMG Global Infotech - App & Web Development Company",
-        description: "IMG Global Infotech, a leading mobile app development company specializing in innovative web and mobile app development services. Discover our story, expertise, and commitment to delivering innovative digital solutions worldwide.",
-        keywords: [
-            'Mobile App Development',
-            'IT Consulting',
-            'Software Development',
-            'USA',
-            'UK',
-            'UAE',
-            'India',
-            'IMG Global Infotech',
-        ],
-        openGraph: {
-            title: "About Us | IMG Global Infotech – Innovating Tech Solutions",
-            description: "Learn about IMG Global Infotech, where innovation meets reality. Our team is accomplished to help businesses grow through cutting-edge technology solutions. Explore our story today!",
-            images: [
-                {
-                url: 'https://d1y41eupgbwbb2.cloudfront.net/images/og/about-us.jpg',
-                width: 1200,
-                height: 630,
-                alt: 'IMG Global Infotech',
-                type: 'image/png',
-                },
-            ],
-            url: process.env.NEXT_PUBLIC_BASE_URL,
-        },
-        twitter: {
-            title: "About Us | IMG Global Infotech – Your Partner in Innovation",
-            description: "Get to know IMG Global Infotech, a team of dedicated experts passionate about delivering innovative tech solutions. Learn how we help businesses through our tailored services.",
-            images: ["https://d1y41eupgbwbb2.cloudfront.net/images/og/about-us.jpg"]
-        },
-        robots: {
-            index: process.env.NODE_ENV === 'production',
-            follow: process.env.NODE_ENV === 'production',
-            nocache: false,
-            googleBot: {
-                index: process.env.NODE_ENV === 'production',
-                follow: process.env.NODE_ENV === 'production',
-                noimageindex: process.env.NODE_ENV === 'production',
-                'max-video-preview': -1,
-                'max-image-preview': 'large',
-                'max-snippet': -1,
-            },
-        },
-        other: {
-            classification: 'Technology'
-        },
-        alternates: {
-            canonical: "/about-us.php"
-        }
-};
+export async function generateMetadata() {
+  return await getDynamicMeta("/about-us.php");
+}
 
 export default function AboutUs() {
   return (

--- a/app/(frontend)/career.php/page.jsx
+++ b/app/(frontend)/career.php/page.jsx
@@ -1,57 +1,9 @@
 import Image from "next/image";
+import getDynamicMeta from "@/helpers/getDynamicMeta";
 
-export const metadata = {
-        title: "Job Openings & Career Growth Opportunities - IMG Global Infotech",
-        description: "Explore exciting career opportunities at IMG Global Infotech. Join our talented professionals and take your skills to the next level with IT, software, and web developer job openings.",
-        keywords: [
-            'Mobile App Development',
-            'IT Consulting',
-            'Software Development',
-            'USA',
-            'UK',
-            'UAE',
-            'India',
-            'IMG Global Infotech',
-        ],
-        openGraph: {
-            title: "Job Openings & Career Growth Opportunities - IMG Global Infotech",
-            description: "Explore exciting career opportunities at IMG Global Infotech. Join our talented professionals and take your skills to the next level with IT, software, and web developer job openings.",
-            images: [
-                {
-                url: 'https://d1y41eupgbwbb2.cloudfront.net/images/og/career.jpg',
-                width: 1200,
-                height: 630,
-                alt: 'IMG Global Infotech',
-                type: 'image/png',
-                },
-            ],
-            url: process.env.NEXT_PUBLIC_BASE_URL,
-        },
-        twitter: {
-            title: "Job Openings & Career Growth Opportunities - IMG Global Infotech",
-            description: "Explore exciting career opportunities at IMG Global Infotech. Join our talented professionals and take your skills to the next level with IT, software, and web developer job openings.",
-            images: ["https://d1y41eupgbwbb2.cloudfront.net/images/og/career.jpg"]
-        },
-        robots: {
-            index: process.env.NODE_ENV === 'production',
-            follow: process.env.NODE_ENV === 'production',
-            nocache: false,
-            googleBot: {
-                index: process.env.NODE_ENV === 'production',
-                follow: process.env.NODE_ENV === 'production',
-                noimageindex: process.env.NODE_ENV === 'production',
-                'max-video-preview': -1,
-                'max-image-preview': 'large',
-                'max-snippet': -1,
-            },
-        },
-        other: {
-            classification: 'Technology'
-        },
-        alternates: {
-            canonical: "/career.php"
-        }
-};
+export async function generateMetadata() {
+  return await getDynamicMeta("/career.php");
+}
 
 export default function Career() {
     return (

--- a/app/(frontend)/page.jsx
+++ b/app/(frontend)/page.jsx
@@ -26,58 +26,11 @@ const Testimonial = dynamic(() => import('@/components/testimonials/Testimonial1
 })
 import Faq from '@/components/Faq';
 import HomeHeroSkeleton from '@/components/skeleton/HomeHeroSkeleton';
+import getDynamicMeta from '@/helpers/getDynamicMeta';
 
-export const metadata = {
-    title: "Mobile App Development & IT Consulting Services in USA | IMG Global Infotech",
-    description: "IMG Global Infotech is a top mobile app development company in USA, UK, UAE, and India, providing expert IT consulting services for startups to large enterprises.",keywords: [
-      'Mobile App Development',
-      'IT Consulting',
-      'Software Development',
-      'USA',
-      'UK',
-      'UAE',
-      'India',
-      'IMG Global Infotech',
-    ],
-    openGraph: {
-      title: "IMG Global Infotech | Mobile App Development & IT Consulting Agency in USA, UK, UAE & India",
-      description: "IMG Global Infotech is the best IT consulting Company that provides the best IT consulting services to startups, mid-size, medium-size and large-size businesses.",
-      images: [
-        {
-          url: 'https://d1y41eupgbwbb2.cloudfront.net/images/android-chrome-192x192.png',
-          width: 1200,
-          height: 630,
-          alt: 'Mobile App Development & IT Consulting Services in USA | IMG Global Infotech',
-          type: 'image/png',
-        },
-      ],
-      url: process.env.NEXT_PUBLIC_BASE_URL,
-    },
-    twitter: {
-      title: "IMG Global Infotech | Mobile App Development & IT Consulting Agency in USA, UK, UAE & India",
-      description: "IMG Global Infotech is the best IT consulting Company that provides the best IT consulting services to startups, mid-size, medium-size and large-size businesses.",
-      images: ["https://d1y41eupgbwbb2.cloudfront.net/images/android-chrome-192x192.png"]
-    },
-    robots: {
-      index: process.env.NODE_ENV === 'production',
-      follow: process.env.NODE_ENV === 'production',
-      nocache: false,
-      googleBot: {
-        index: process.env.NODE_ENV === 'production',
-        follow: process.env.NODE_ENV === 'production',
-        noimageindex: process.env.NODE_ENV === 'production',
-        'max-video-preview': -1,
-        'max-image-preview': 'large',
-        'max-snippet': -1,
-      },
-    },
-    other: {
-      classification: 'Technology'
-    },
-    alternates: {
-      canonical: '/'
-    }
-};
+export async function generateMetadata() {
+  return await getDynamicMeta('/');
+}
 
 
   const graphSchema = {

--- a/app/admin/new-admin/page.jsx
+++ b/app/admin/new-admin/page.jsx
@@ -1,20 +1,12 @@
 import RegisterForm from "./registerForm";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import getDynamicMeta from "@/helpers/getDynamicMeta";
+
+export async function generateMetadata() {
+  return await getDynamicMeta("/admin/new-admin");
+}
 
 const title = "Register";
-
-export const metadata = {
-  title,
-  description: "Register for an account",
-  robots: {
-    index: true,
-    follow: true,
-  },
-  openGraph: {
-    title,
-    images: [`/api/og?title=${title}`],
-  },
-};
 
 const page = () => {
   return (

--- a/helpers/getDynamicMeta.js
+++ b/helpers/getDynamicMeta.js
@@ -1,0 +1,29 @@
+export default async function getDynamicMeta(pageUrl) {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/dynamic?pageUrl=${encodeURIComponent(pageUrl)}`,
+      { cache: 'no-store' }
+    );
+    const json = await res.json();
+    if (json.success && json.data) {
+      const data = json.data;
+      const toUrl = (u) =>
+        u && !u.startsWith('http')
+          ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${u}`
+          : u;
+      if (data.openGraph?.images?.length) {
+        data.openGraph.images = data.openGraph.images.map((img) => ({
+          ...img,
+          url: toUrl(img.url),
+        }));
+      }
+      if (data.twitter?.images?.length) {
+        data.twitter.images = data.twitter.images.map(toUrl);
+      }
+      return data;
+    }
+  } catch (err) {
+    console.error('Error fetching dynamic meta:', err);
+  }
+  return {};
+}


### PR DESCRIPTION
## Summary
- add helper to fetch dynamic meta from API
- generate page metadata dynamically for public and auth pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696b48806c8328800618ffc78d1251