### PR TITLE
Add meta index page

### DIFF
--- a/app/admin/meta/loading.jsx
+++ b/app/admin/meta/loading.jsx
@@ -1,0 +1,5 @@
+import MetaIndexSkeleton from "@/components/skeleton/meta-index-skeleton";
+
+export default function Loading() {
+  return <MetaIndexSkeleton />;
+}

--- a/app/admin/meta/page.jsx
+++ b/app/admin/meta/page.jsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+
+export default function Page() {
+  return (
+    <div className="grid gap-4 p-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Link href="/admin/meta/static" className="contents">
+          <Card className="cursor-pointer hover:shadow-md transition-shadow">
+            <CardHeader>
+              <CardTitle>Static Meta</CardTitle>
+              <CardDescription>Manage static metadata</CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+        <Link href="/admin/meta/dynamic" className="contents">
+          <Card className="cursor-pointer hover:shadow-md transition-shadow">
+            <CardHeader>
+              <CardTitle>Dynamic Meta</CardTitle>
+              <CardDescription>Manage dynamic metadata</CardDescription>
+            </CardHeader>
+          </Card>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/skeleton/meta-index-skeleton.jsx
+++ b/components/skeleton/meta-index-skeleton.jsx
@@ -1,0 +1,29 @@
+"use client";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+
+export default function MetaIndexSkeleton() {
+  return (
+    <div className="grid gap-4 p-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {[...Array(2)].map((_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <CardTitle>
+                <Skeleton className="h-6 w-32" />
+              </CardTitle>
+              <CardDescription>
+                <Skeleton className="h-4 w-24" />
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add skeleton for meta section
- add index page linking to static and dynamic meta forms
- wire the skeleton to `loading.jsx`

## Testing
- `npm run lint`
- `npm run build` *(fails: No key set vapidDetails.publicKey)*

------
https://chatgpt.com/codex/tasks/task_e_686a2670f0c4832881d28ae1de51ba86