### PR TITLE
Fix loading states on admin forms

### DIFF
--- a/app/admin/admins/[id]/edit/EditAdminForm.jsx
+++ b/app/admin/admins/[id]/edit/EditAdminForm.jsx
@@ -228,7 +228,11 @@ export default function EditAdminForm({
             )}
           />
         )}
-        <Button type="submit" disabled={form.formState.isSubmitting} className="w-full">
+        <Button
+          type="submit"
+          disabled={form.formState.isSubmitting}
+          className="w-full cursor-pointer"
+        >
           {form.formState.isSubmitting ? "Updating..." : "Update"}
         </Button>
       </form>

--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -978,7 +978,11 @@ export default function Page({ params }) {
                         >
                         Cancel
                       </Button>
-                      <Button type="submit" disabled={form.formState.isSubmitting}>
+                      <Button
+                        type="submit"
+                        className="cursor-pointer"
+                        disabled={form.formState.isSubmitting}
+                      >
                         {form.formState.isSubmitting ? "Updating..." : "Update"}
                       </Button>
                     </div>

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -1130,7 +1130,11 @@ function BlogAdd() {
                       </div>
                     )}
                     <div className="w-full flex justify-end gap-4">
-                      <Button type="submit" disabled={form.formState.isSubmitting}>
+                      <Button
+                        type="submit"
+                        className="cursor-pointer"
+                        disabled={form.formState.isSubmitting}
+                      >
                         {status === "1"
                           ? (form.formState.isSubmitting ? "Saving..." : "Save Draft")
                           : (form.formState.isSubmitting ? "Publishing..." : "Publish Now")}

--- a/app/admin/blogs/authors/[id]/edit/EditAuthorForm.jsx
+++ b/app/admin/blogs/authors/[id]/edit/EditAuthorForm.jsx
@@ -244,7 +244,11 @@ export default function EditAuthorForm({ author }) {
                 )}
               />
               <div className="flex justify-end gap-4">
-                <Button type="submit" disabled={form.formState.isSubmitting}>
+                <Button
+                  type="submit"
+                  className="cursor-pointer"
+                  disabled={form.formState.isSubmitting}
+                >
                   {form.formState.isSubmitting ? "Updating..." : "Update Author"}
                 </Button>
               </div>

--- a/app/admin/blogs/authors/add/page.jsx
+++ b/app/admin/blogs/authors/add/page.jsx
@@ -221,7 +221,11 @@ export default function Page() {
                   </div>
 
                   <div className="flex justify-end gap-4">
-                    <Button type="submit" disabled={form.formState.isSubmitting}>
+                    <Button
+                      type="submit"
+                      className="cursor-pointer"
+                      disabled={form.formState.isSubmitting}
+                    >
                       {form.formState.isSubmitting ? "Creating..." : "Create Author"}
                     </Button>
                   </div>

--- a/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
+++ b/app/admin/blogs/categories/[id]/edit/EditCategoryForm.jsx
@@ -134,7 +134,11 @@ export default function EditCategoryForm({ category }) {
                 )}
               />
               <div className="flex justify-end gap-4">
-                <Button type="submit" disabled={form.formState.isSubmitting}>
+                <Button
+                  type="submit"
+                  className="cursor-pointer"
+                  disabled={form.formState.isSubmitting}
+                >
                   {form.formState.isSubmitting ? "Updating..." : "Update Category"}
                 </Button>
               </div>

--- a/app/admin/blogs/categories/add/page.jsx
+++ b/app/admin/blogs/categories/add/page.jsx
@@ -118,7 +118,11 @@ export default function Page() {
                     )}
                   />
                   <div className="flex justify-end gap-4">
-                    <Button type="submit" disabled={form.formState.isSubmitting}>
+                    <Button
+                      type="submit"
+                      className="cursor-pointer"
+                      disabled={form.formState.isSubmitting}
+                    >
                       {form.formState.isSubmitting ? "Creating..." : "Create Category"}
                     </Button>
                   </div>

--- a/app/admin/blogs/images/[id]/edit/EditImageForm.jsx
+++ b/app/admin/blogs/images/[id]/edit/EditImageForm.jsx
@@ -95,7 +95,11 @@ export default function EditImageForm({ image }) {
                 </FormItem>
               )}
             />
-            <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+            <Button
+              type="submit"
+              className="w-full cursor-pointer"
+              disabled={form.formState.isSubmitting}
+            >
               {form.formState.isSubmitting ? 'Updating...' : 'Update Image'}
             </Button>
           </form>

--- a/app/admin/blogs/images/add/page.jsx
+++ b/app/admin/blogs/images/add/page.jsx
@@ -110,7 +110,7 @@ export default function AddImagePage() {
                 />
                 <Button
                   type="submit"
-                  className="w-full"
+                  className="w-full cursor-pointer"
                   disabled={form.formState.isSubmitting}
                 >
                   {form.formState.isSubmitting

--- a/app/admin/leads/[id]/edit/page.jsx
+++ b/app/admin/leads/[id]/edit/page.jsx
@@ -177,7 +177,13 @@ export default function Page({ params }) {
                 </div>
               )}
               <div className="flex justify-end">
-                <Button type="submit" disabled={form.formState.isSubmitting}>{form.formState.isSubmitting ? 'Saving...' : 'Save'}</Button>
+                <Button
+                  type="submit"
+                  className="cursor-pointer"
+                  disabled={form.formState.isSubmitting}
+                >
+                  {form.formState.isSubmitting ? 'Saving...' : 'Save'}
+                </Button>
               </div>
             </form>
           </Form>

--- a/app/admin/leads/add/page.jsx
+++ b/app/admin/leads/add/page.jsx
@@ -112,7 +112,13 @@ export default function Page() {
                 </FormItem>
               )} />
               <div className="flex justify-end">
-                <Button type="submit" disabled={form.formState.isSubmitting}>{form.formState.isSubmitting ? 'Creating...' : 'Create'}</Button>
+                <Button
+                  type="submit"
+                  className="cursor-pointer"
+                  disabled={form.formState.isSubmitting}
+                >
+                  {form.formState.isSubmitting ? 'Creating...' : 'Create'}
+                </Button>
               </div>
             </form>
           </Form>

--- a/app/admin/meta/dynamic/[slug]/page.jsx
+++ b/app/admin/meta/dynamic/[slug]/page.jsx
@@ -406,7 +406,13 @@ export default function Page() {
             </FormItem>
           )} />
           <div className="flex justify-end">
-            <Button type="submit">Save</Button>
+            <Button
+              type="submit"
+              className="cursor-pointer"
+              disabled={form.formState.isSubmitting}
+            >
+              {form.formState.isSubmitting ? 'Saving...' : 'Save'}
+            </Button>
           </div>
         </form>
       </Form>

--- a/app/admin/newsletter/add/page.jsx
+++ b/app/admin/newsletter/add/page.jsx
@@ -51,7 +51,13 @@ export default function Page() {
                 </FormItem>
               )} />
               <div className="flex justify-end">
-                <Button type="submit" disabled={form.formState.isSubmitting}>{form.formState.isSubmitting ? 'Submitting...' : 'Submit'}</Button>
+                <Button
+                  type="submit"
+                  className="cursor-pointer"
+                  disabled={form.formState.isSubmitting}
+                >
+                  {form.formState.isSubmitting ? 'Submitting...' : 'Submit'}
+                </Button>
               </div>
             </form>
           </Form>

--- a/app/admin/schema/[slug]/add/page.jsx
+++ b/app/admin/schema/[slug]/add/page.jsx
@@ -947,7 +947,11 @@ export default function Page() {
             </div>
           )}
           <div className="flex justify-end pt-4">
-            <Button type="submit" disabled={form.formState.isSubmitting}>
+            <Button
+              type="submit"
+              className="cursor-pointer"
+              disabled={form.formState.isSubmitting}
+            >
               {form.formState.isSubmitting ? "Saving..." : "Save"}
             </Button>
           </div>

--- a/components/RedirectionForm.jsx
+++ b/components/RedirectionForm.jsx
@@ -114,7 +114,7 @@ export default function RedirectionForm({ fromDefault = "", onSuccess }) {
         <Button
           type="submit"
           disabled={form.formState.isSubmitting}
-          className="w-full"
+          className="w-full cursor-pointer"
         >
           {form.formState.isSubmitting ? "Adding..." : "Add Redirection"}
         </Button>

--- a/components/department-form.jsx
+++ b/components/department-form.jsx
@@ -200,7 +200,11 @@ export default function DepartmentForm({ department, onSuccess }) {
             </Table>
           </div>
         </div>
-        <Button type="submit" disabled={form.formState.isSubmitting}>
+        <Button
+          type="submit"
+          className="cursor-pointer"
+          disabled={form.formState.isSubmitting}
+        >
           {form.formState.isSubmitting
             ? department
               ? "Updating..."


### PR DESCRIPTION
## Summary
- show loading text on dynamic meta save button and add cursor classes
- add cursor styles to various submit buttons for consistent UX

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a2ee7f1c08328bcc09877be9a809e