### PR TITLE
Limit permission stamp check to admin pages

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -85,7 +85,8 @@ export async function middleware(request) {
     const isEmail = decodedToken?.email;
 
     const permStamp = request.cookies.get('permissionsStamp')?.value;
-    if (decodedToken && permStamp) {
+    const shouldCheckPermissions = pathname.startsWith('/admin') || pathname.startsWith('/blog');
+    if (shouldCheckPermissions && decodedToken && permStamp) {
         try {
             const res = await fetch(`${origin}/api/v1/admin/admins/me`, {
                 headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
## Summary
- avoid hitting `/api/v1/admin/admins/me` on public pages

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a3350f6048328bdfb3b1c9ab261e9