### PR TITLE
Improve error page styling

### DIFF
--- a/app/error.js
+++ b/app/error.js
@@ -1,24 +1,36 @@
-'use client' // Error boundaries must be Client Components
- 
-import { useEffect } from 'react'
- 
+"use client";
+
+import { useEffect } from "react";
+import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
 export default function Error({ error, reset }) {
   useEffect(() => {
     // Log the error to an error reporting service
-    console.error(error)
-  }, [error])
- 
+    console.error(error);
+  }, [error]);
+
   return (
-    <div>
-      <h2>Something went wrong!</h2>
-      <button
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
-      >
-        Try again
-      </button>
+    <div className="flex h-dvh items-center justify-center p-4">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader className="flex flex-col items-center gap-2">
+          <AlertCircle className="size-12 text-destructive" />
+          <CardTitle className="text-2xl">Something went wrong!</CardTitle>
+          <CardDescription>
+            An unexpected error occurred. Please try again.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button onClick={() => reset()}>Try again</Button>
+        </CardContent>
+      </Card>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- redesign the global `error.js` page with shadcn UI components

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a3c6895608328b05c6ef61158dbad