### PR TITLE
Style not-found page

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -1,11 +1,23 @@
 import Link from 'next/link'
- 
+import { AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+
 export default function NotFound() {
   return (
-    <div>
-      <h2>Not Found</h2>
-      <p>Could not find requested resource</p>
-      <Link href="/">Return Home</Link>
-    </div>
+    <main className="flex items-center justify-center py-10 min-h-[60vh]">
+      <Card className="w-full max-w-md text-center">
+        <CardHeader>
+          <AlertTriangle className="mx-auto mb-2 size-12 text-destructive" />
+          <CardTitle>Page Not Found</CardTitle>
+          <CardDescription>The page you are looking for does not exist.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild className="mx-auto">
+            <Link href="/">Return Home</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
   )
 }


### PR DESCRIPTION
## Summary
- make `not-found.js` use shadcn/ui components for a cleaner look

## Testing
- `npm run lint`
- `npm run build` *(fails: No key set vapidDetails.publicKey)*

------
https://chatgpt.com/codex/tasks/task_e_686a3d3d521c8328a64118800faba952