### PR TITLE
Implement API-based static metadata

### DIFF
--- a/app/(frontend)/layout.jsx
+++ b/app/(frontend)/layout.jsx
@@ -6,7 +6,19 @@ import PageSchema from "@/components/page-schema";
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import schemaToLd from "@/helpers/schemaToLd";
+import getStaticMeta from "@/helpers/getStaticMeta";
+
+
+export async function generateMetadata() {
+  const meta = await getStaticMeta();
+  return {
+    metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL),
+    ...meta,
+  };
+}
+
 export default async function RootLayout({ children }) {
+
   async function getSchema(type) {
     try {
       const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/schema?global=true&type=${type}`, { cache: "no-store" });

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -2,6 +2,7 @@ import { Poppins } from "next/font/google";
 import "@/app/globals.css";
 import { Toaster } from "sonner";
 import PushInit from "@/components/PushInit";
+import getStaticMeta from "@/helpers/getStaticMeta";
 
 const poppins = Poppins({
   weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"], // choose weights you want
@@ -9,125 +10,13 @@ const poppins = Poppins({
   subsets: ["latin"],
 });
 
-export const metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL),
-  title: {
-    default: 'Mobile App Development & IT Consulting Services in USA | IMG Global Infotech',
-    template: '%s',
-  },
-  description: 'IMG Global Infotech is a top mobile app development company in USA, UK, UAE, and India, providing expert IT consulting services for startups to large enterprises.',
-  keywords: [
-    'Mobile App Development',
-    'IT Consulting',
-    'Software Development',
-    'USA',
-    'UK',
-    'UAE',
-    'India',
-    'IMG Global Infotech',
-  ],
-  authors: [
-    { name: 'Mr. Mohit Mittal' },
-    { name: 'IMG Global Infotech', url: process.env.NEXT_PUBLIC_BASE_URL },
-  ],
-  creator: 'IMG Global Infotech',
-  publisher: 'IMG Global Infotech',
-  formatDetection: {
-    email: false,
-    address: false,
-    telephone: false,
-  },
-  robots: {
-    index: process.env.NODE_ENV === 'production',
-    follow: process.env.NODE_ENV === 'production',
-    nocache: false,
-    googleBot: {
-      index: process.env.NODE_ENV === 'production',
-      follow: process.env.NODE_ENV === 'production',
-      noimageindex: process.env.NODE_ENV === 'production',
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
-    },
-  },
-  generator: 'Next.js 15.3.3 + Tailwind CSS',
-  applicationName: 'IMG Global Infotech',
-  referrer: 'origin-when-cross-origin',
-  manifest: '/site.webmanifest',
-  openGraph: {
-    title:
-      'IMG Global Infotech | Mobile App Development & IT Consulting Agency in USA, UK, UAE & India',
-    description:
-      'IMG Global Infotech is the best IT consulting Company that provides the best IT consulting services to startups, mid-size, medium-size and large-size businesses.',
-    url: process.env.NEXT_PUBLIC_BASE_URL,
-    siteName: 'IMG Global Infotech',
-    locale: 'en_US',
-    type: 'website',
-    images: [
-      {
-        url: '/android-chrome-192x192.png',
-        width: 1200,
-        height: 630,
-        alt: 'IMG Global Infotech',
-        type: 'image/jpg',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'IMG Global Infotech | Mobile App Development & IT Consulting Agency in USA, UK, UAE & India',
-    description: 'IMG Global Infotech is the best IT consulting Company that provides the best IT consulting services to startups, mid-size, medium-size and large-size businesses.',
-    site: '@imgglobal',
-    creator: '@imgglobal',
-    images: ['/android-chrome-192x192.png'],
-  },
-  icons: {
-    icon: [
-      { url: '/favicon-32x32.png', sizes: '32x32' },
-      { url: '/favicon-16x16.png', sizes: '16x16' },
-    ],
-    shortcut: '/favicon.ico',
-    apple: '/apple-touch-icon.png',
-    other: [
-      {
-        rel: 'mask-icon',
-        url: '/safari-pinned-tab.svg',
-        color: '#000019',
-      },
-      {
-        rel: 'apple-touch-icon-precomposed',
-        url: '/apple-touch-icon.png',
-      },
-    ],
-  },
-  verification: {
-    google: process.env.NODE_ENV === 'production'
-      ? 'BBLrFK7anf4GPwYJU5gnYITc6dEOjYAaDzRldFFpw0A'
-      : 'b3JyKKuxkNseCK4ci5FbXB7AQnSW5jFjBkdW22XWmsc',
-    microsoft: process.env.NODE_ENV === 'production'
-      ? '1CF4AABD4C8EFCCFAFF1458BE10E8FC8'
-      : '',
-    other: {
-      fb: '151060611741013',
-    },
-  },
-  appleWebApp: {
-    title: 'IMG Global Infotech',
-    statusBarStyle: 'black-translucent',
-    capable: true,
-    startupImage: [
-      '/apple-touch-startup-image-768x1004.png',
-      {
-        url: '/apple-touch-startup-image-1536x2008.png',
-        media: '(device-width: 768px) and (device-height: 1024px)',
-      },
-    ],
-  },
-  category: 'technology',
-  pinterest: {
-    richPin: true,
-  },
-};
+export async function generateMetadata() {
+  const meta = await getStaticMeta();
+  return {
+    metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL),
+    ...meta,
+  };
+}
 
 export const viewport = {
   themeColor: '#000019',

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -2,7 +2,6 @@ import { Poppins } from "next/font/google";
 import "@/app/globals.css";
 import { Toaster } from "sonner";
 import PushInit from "@/components/PushInit";
-import getStaticMeta from "@/helpers/getStaticMeta";
 
 const poppins = Poppins({
   weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"], // choose weights you want
@@ -10,13 +9,6 @@ const poppins = Poppins({
   subsets: ["latin"],
 });
 
-export async function generateMetadata() {
-  const meta = await getStaticMeta();
-  return {
-    metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL),
-    ...meta,
-  };
-}
 
 export const viewport = {
   themeColor: '#000019',

--- a/helpers/getStaticMeta.js
+++ b/helpers/getStaticMeta.js
@@ -1,0 +1,33 @@
+export default async function getStaticMeta() {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/static`,
+      { cache: 'no-store' }
+    );
+    const json = await res.json();
+    if (json.success && json.data) {
+      const data = json.data;
+      const toUrl = (u) =>
+        u && !u.startsWith('http')
+          ? `${process.env.NEXT_PUBLIC_CLOUDFRONT_URL}/images/${u}`
+          : u;
+      data.openGraph.images = data.openGraph.images.map((img) => ({
+        ...img,
+        url: toUrl(img.url),
+      }));
+      data.twitter.images = data.twitter.images.map(toUrl);
+      data.icons.icon = data.icons.icon.map((i) => ({ ...i, url: toUrl(i.url) }));
+      data.icons.shortcut = toUrl(data.icons.shortcut);
+      data.icons.apple = toUrl(data.icons.apple);
+      data.icons.other = data.icons.other.map((i) => ({ ...i, url: toUrl(i.url) }));
+      data.appleWebApp.startupImage.mainImageUrl = toUrl(
+        data.appleWebApp.startupImage.mainImageUrl
+      );
+      data.appleWebApp.startupImage.url = toUrl(data.appleWebApp.startupImage.url);
+      return data;
+    }
+  } catch (err) {
+    console.error('Error fetching static meta:', err);
+  }
+  return {};
+}


### PR DESCRIPTION
## Summary
- fetch static metadata from API via new helper
- use `generateMetadata` in app layout for dynamic static meta

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b725a0b848328b5b6f636e41b1d18