### PR TITLE
Use select controls for limited static meta fields

### DIFF
--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -16,6 +16,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import MultiKeywordCombobox from "@/components/ui/multi-keyword-combobox";
 import ImageCropperInput from "@/components/image-cropper-input";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -47,6 +54,33 @@ const defaultMeta = {
   description: "",
   title: { default: "" },
 };
+
+const ogTypes = [
+  "article",
+  "book",
+  "music.song",
+  "music.album",
+  "music.playlist",
+  "music.radio_station",
+  "profile",
+  "website",
+  "video.tv_show",
+  "video.other",
+  "video.movie",
+  "video.episode",
+];
+
+const ogImageTypes = [
+  { value: "image/jpeg", label: "jpg" },
+  { value: "image/png", label: "png" },
+  { value: "image/webp", label: "webp" },
+];
+
+const statusBarStyles = [
+  "default",
+  "black",
+  "black-translucent",
+];
 
 function mergeDeep(target, source) {
   for (const key in source) {
@@ -385,7 +419,21 @@ export default function EditStaticMetaForm({ meta }) {
                     <FormItem>
                       <FormLabel>Type</FormLabel>
                       <FormControl>
-                        <Input {...field} />
+                        <Select
+                          value={field.value}
+                          onValueChange={(val) => field.onChange(val)}
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {ogTypes.map((opt) => (
+                              <SelectItem key={opt} value={opt}>
+                                {opt}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -473,7 +521,21 @@ export default function EditStaticMetaForm({ meta }) {
                         <FormItem className="grow">
                           <FormLabel>Type</FormLabel>
                           <FormControl>
-                            <Input {...field} />
+                            <Select
+                              value={field.value}
+                              onValueChange={(val) => field.onChange(val)}
+                            >
+                              <SelectTrigger className="w-full">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {ogImageTypes.map((t) => (
+                                  <SelectItem key={t.value} value={t.value}>
+                                    {t.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -819,7 +881,21 @@ export default function EditStaticMetaForm({ meta }) {
                   <FormItem>
                     <FormLabel>Status Bar Style</FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <Select
+                        value={field.value}
+                        onValueChange={(val) => field.onChange(val)}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {statusBarStyles.map((s) => (
+                            <SelectItem key={s} value={s}>
+                              {s}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -424,7 +424,7 @@ export default function EditStaticMetaForm({ meta }) {
                           onValueChange={(val) => field.onChange(val)}
                         >
                           <SelectTrigger className="w-full">
-                            <SelectValue />
+                            <SelectValue placeholder="Select type" />
                           </SelectTrigger>
                           <SelectContent>
                             {ogTypes.map((opt) => (
@@ -526,7 +526,7 @@ export default function EditStaticMetaForm({ meta }) {
                               onValueChange={(val) => field.onChange(val)}
                             >
                               <SelectTrigger className="w-full">
-                                <SelectValue />
+                                <SelectValue placeholder="Select type" />
                               </SelectTrigger>
                               <SelectContent>
                                 {ogImageTypes.map((t) => (
@@ -886,7 +886,7 @@ export default function EditStaticMetaForm({ meta }) {
                         onValueChange={(val) => field.onChange(val)}
                       >
                         <SelectTrigger className="w-full">
-                          <SelectValue />
+                          <SelectValue placeholder="Select style" />
                         </SelectTrigger>
                         <SelectContent>
                           {statusBarStyles.map((s) => (

--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -420,8 +420,8 @@ export default function EditStaticMetaForm({ meta }) {
                       <FormLabel>Type</FormLabel>
                       <FormControl>
                         <Select
-                          defaultValue={field.value}
-                          onValueChange={(val) => field.onChange(val)}
+                          value={field.value}
+                          onValueChange={field.onChange}
                         >
                           <SelectTrigger className="w-full">
                             <SelectValue placeholder="Select type" />
@@ -522,8 +522,8 @@ export default function EditStaticMetaForm({ meta }) {
                           <FormLabel>Type</FormLabel>
                           <FormControl>
                             <Select
-                              defaultValue={field.value}
-                              onValueChange={(val) => field.onChange(val)}
+                              value={field.value}
+                              onValueChange={field.onChange}
                             >
                               <SelectTrigger className="w-full">
                                 <SelectValue placeholder="Select type" />
@@ -882,8 +882,8 @@ export default function EditStaticMetaForm({ meta }) {
                     <FormLabel>Status Bar Style</FormLabel>
                     <FormControl>
                       <Select
-                        defaultValue={field.value}
-                        onValueChange={(val) => field.onChange(val)}
+                        value={field.value}
+                        onValueChange={field.onChange}
                       >
                         <SelectTrigger className="w-full">
                           <SelectValue placeholder="Select style" />

--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -420,7 +420,8 @@ export default function EditStaticMetaForm({ meta }) {
                       <FormLabel>Type</FormLabel>
                       <FormControl>
                         <Select
-                          value={field.value}
+                          key={field.value}
+                          value={field.value || ""}
                           onValueChange={field.onChange}
                         >
                           <SelectTrigger className="w-full">
@@ -522,7 +523,8 @@ export default function EditStaticMetaForm({ meta }) {
                           <FormLabel>Type</FormLabel>
                           <FormControl>
                             <Select
-                              value={field.value}
+                              key={field.value}
+                              value={field.value || ""}
                               onValueChange={field.onChange}
                             >
                               <SelectTrigger className="w-full">
@@ -882,7 +884,8 @@ export default function EditStaticMetaForm({ meta }) {
                     <FormLabel>Status Bar Style</FormLabel>
                     <FormControl>
                       <Select
-                        value={field.value}
+                        key={field.value}
+                        value={field.value || ""}
                         onValueChange={field.onChange}
                       >
                         <SelectTrigger className="w-full">

--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -420,7 +420,7 @@ export default function EditStaticMetaForm({ meta }) {
                       <FormLabel>Type</FormLabel>
                       <FormControl>
                         <Select
-                          value={field.value}
+                          defaultValue={field.value}
                           onValueChange={(val) => field.onChange(val)}
                         >
                           <SelectTrigger className="w-full">
@@ -522,7 +522,7 @@ export default function EditStaticMetaForm({ meta }) {
                           <FormLabel>Type</FormLabel>
                           <FormControl>
                             <Select
-                              value={field.value}
+                              defaultValue={field.value}
                               onValueChange={(val) => field.onChange(val)}
                             >
                               <SelectTrigger className="w-full">
@@ -882,7 +882,7 @@ export default function EditStaticMetaForm({ meta }) {
                     <FormLabel>Status Bar Style</FormLabel>
                     <FormControl>
                       <Select
-                        value={field.value}
+                        defaultValue={field.value}
                         onValueChange={(val) => field.onChange(val)}
                       >
                         <SelectTrigger className="w-full">

--- a/app/admin/meta/static/EditStaticMetaForm.jsx
+++ b/app/admin/meta/static/EditStaticMetaForm.jsx
@@ -420,7 +420,7 @@ export default function EditStaticMetaForm({ meta }) {
                       <FormLabel>Type</FormLabel>
                       <FormControl>
                         <Select
-                          defaultValue={field.value}
+                          value={field.value}
                           onValueChange={(val) => field.onChange(val)}
                         >
                           <SelectTrigger className="w-full">
@@ -522,7 +522,7 @@ export default function EditStaticMetaForm({ meta }) {
                           <FormLabel>Type</FormLabel>
                           <FormControl>
                             <Select
-                              defaultValue={field.value}
+                              value={field.value}
                               onValueChange={(val) => field.onChange(val)}
                             >
                               <SelectTrigger className="w-full">
@@ -882,7 +882,7 @@ export default function EditStaticMetaForm({ meta }) {
                     <FormLabel>Status Bar Style</FormLabel>
                     <FormControl>
                       <Select
-                        defaultValue={field.value}
+                        value={field.value}
                         onValueChange={(val) => field.onChange(val)}
                       >
                         <SelectTrigger className="w-full">


### PR DESCRIPTION
## Summary
- convert OpenGraph type, OpenGraph image type and apple status bar style to Select components in the static meta form
- add option constants for these selects

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b77ead0588328931242acf0314e88