### PR TITLE
Add mobile header avatar dropdown

### DIFF
--- a/app/admin/layout.jsx
+++ b/app/admin/layout.jsx
@@ -1,11 +1,7 @@
 import { AppSidebar } from "@/components/app-sidebar"
-import { DynamicBreadcrumb } from "@/components/breadcrumb";
-import { Separator } from "@/components/ui/separator";
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from "@/components/ui/sidebar"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { Separator } from "@/components/ui/separator"
+import { AppHeader } from "@/components/app-header"
 
 
 export default function AdminLayout({ children }) {
@@ -13,13 +9,7 @@ export default function AdminLayout({ children }) {
     <SidebarProvider>
       <AppSidebar />
       <SidebarInset>
-        <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-          <div className="flex items-center gap-2 px-4">
-            <SidebarTrigger className="-ml-1" />
-            <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-            <DynamicBreadcrumb />
-          </div>
-        </header>
+        <AppHeader />
         <Separator />
         {children}
       </SidebarInset>

--- a/components/app-header.jsx
+++ b/components/app-header.jsx
@@ -1,0 +1,34 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar'
+import { Separator } from '@/components/ui/separator'
+import { DynamicBreadcrumb } from '@/components/breadcrumb'
+import { NavUserSkeleton } from '@/components/skeleton/nav-user-skeleton'
+
+const NavUser = dynamic(
+  () => import('@/components/nav-user').then(mod => mod.NavUser),
+  {
+    loading: () => <NavUserSkeleton />,
+    ssr: false,
+  }
+)
+
+export function AppHeader() {
+  const { isMobile } = useSidebar()
+
+  return (
+    <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+      <div className="flex items-center gap-2 px-4">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+        {!isMobile && <DynamicBreadcrumb />}
+      </div>
+      {isMobile && (
+        <div className="ml-auto px-4">
+          <NavUser />
+        </div>
+      )}
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- create `AppHeader` component with user dropdown shown on mobile
- update admin layout to use new header

## Testing
- `npx eslint components/app-header.jsx` *(fails: cannot find package '@eslint/eslintrc')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b932055a0832883f470ab06a5dfa0