### PR TITLE
Fix CSP for analytics

### DIFF
--- a/app/middleware/security.js
+++ b/app/middleware/security.js
@@ -19,7 +19,17 @@ export function securityMiddleware(req) {
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  response.headers.set('Content-Security-Policy', "default-src 'self' https://cdn.tiny.cloud; connect-src 'self' https://ipinfo.io https://cdn.tiny.cloud; img-src 'self' https://cdn.tiny.cloud blob: data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tiny.cloud; style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud; font-src 'self' 'unsafe-inline' data: https://cdn.tiny.cloud;");
+  response.headers.set(
+    'Content-Security-Policy',
+    [
+      "default-src 'self' https: blob:",
+      "connect-src 'self' https://ipinfo.io https://cdn.tiny.cloud https://embed.tawk.to https://www.googletagmanager.com https://www.google-analytics.com",
+      "img-src 'self' https://cdn.tiny.cloud blob: data: https:",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tiny.cloud https://www.googletagmanager.com https://embed.tawk.to",
+      "style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud",
+      "font-src 'self' 'unsafe-inline' data: https://cdn.tiny.cloud",
+    ].join('; ')
+  );
   response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
   return response;

--- a/middleware.js
+++ b/middleware.js
@@ -49,7 +49,17 @@ export async function middleware(request) {
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-  response.headers.set('Content-Security-Policy', "default-src 'self' https://cdn.tiny.cloud; connect-src 'self' https://ipinfo.io https://cdn.tiny.cloud; img-src 'self' https://cdn.tiny.cloud blob: data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tiny.cloud; style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud; font-src 'self' 'unsafe-inline' data: https://cdn.tiny.cloud;");
+  response.headers.set(
+    'Content-Security-Policy',
+    [
+      "default-src 'self' https: blob:",
+      "connect-src 'self' https://ipinfo.io https://cdn.tiny.cloud https://embed.tawk.to https://www.googletagmanager.com https://www.google-analytics.com",
+      "img-src 'self' https://cdn.tiny.cloud blob: data: https:",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tiny.cloud https://www.googletagmanager.com https://embed.tawk.to",
+      "style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud",
+      "font-src 'self' 'unsafe-inline' data: https://cdn.tiny.cloud",
+    ].join('; ')
+  );
   response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
   const { pathname, search, origin } = request.nextUrl;


### PR DESCRIPTION
## Summary
- relax Content Security Policy headers to allow tawk and Google tag manager

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bb497bec48328a21bccba151674b6