### PR TITLE
Implement nonce-based CSP for tawk

### DIFF
--- a/app/(frontend)/layout.jsx
+++ b/app/(frontend)/layout.jsx
@@ -3,6 +3,7 @@ import Footer from "@/components/Footer";
 import LeadPopup from "@/components/leadPopup";
 import TawkToWidget from "@/components/TawkToWidget";
 import PageSchema from "@/components/page-schema";
+import { headers } from 'next/headers'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import schemaToLd from "@/helpers/schemaToLd";
@@ -18,6 +19,7 @@ export async function generateMetadata() {
 }
 
 export default async function RootLayout({ children }) {
+  const nonce = (await headers()).get('x-nonce')
 
   async function getSchema(type) {
     try {
@@ -45,6 +47,7 @@ export default async function RootLayout({ children }) {
       {LocalBusiness && (
         <script
           type="application/ld+json"
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(LocalBusiness).replace(/</g, '\\u003c'),
           }}
@@ -53,6 +56,7 @@ export default async function RootLayout({ children }) {
       {LocalBusiness2 && (
         <script
           type="application/ld+json"
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(LocalBusiness2).replace(/</g, '\\u003c'),
           }}
@@ -61,12 +65,13 @@ export default async function RootLayout({ children }) {
         {Organization && (
           <script
             type="application/ld+json"
+            nonce={nonce}
             dangerouslySetInnerHTML={{
               __html: JSON.stringify(Organization).replace(/</g, '\\u003c'),
             }}
           />
         )}
-        <PageSchema />
+        <PageSchema nonce={nonce} />
         <Navbar/>
         <main>
         {children}
@@ -75,9 +80,9 @@ export default async function RootLayout({ children }) {
         <Footer/>
         {isProd && (
           <>
-            <TawkToWidget />
-            <GoogleAnalytics gaId="G-N2Q0NVDS4P" />
-            <SpeedInsights/>
+            <TawkToWidget nonce={nonce} />
+            <GoogleAnalytics gaId="G-N2Q0NVDS4P" nonce={nonce} />
+            <SpeedInsights />
           </>
         )}
     </>

--- a/components/TawkToWidget.jsx
+++ b/components/TawkToWidget.jsx
@@ -2,19 +2,20 @@
 
 import { useEffect } from 'react'
 
-const TawkToWidget = () => {
+const TawkToWidget = ({ nonce }) => {
   useEffect(() => {
     const script = document.createElement('script')
     script.src = 'https://embed.tawk.to/66cc5e1450c10f7a00a07d00/1i674v16o'
     script.async = true
     script.crossOrigin = '*'
+    if (nonce) script.nonce = nonce
 
     document.body.appendChild(script)
 
     return () => {
       document.body.removeChild(script)
     }
-  }, [])
+  }, [nonce])
 
   return null
 }

--- a/components/page-schema.jsx
+++ b/components/page-schema.jsx
@@ -3,7 +3,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import schemaToLd from "@/helpers/schemaToLd";
 
-export default function PageSchema() {
+export default function PageSchema({ nonce }) {
   const pathname = usePathname();
   const [lds, setLds] = useState([]);
 
@@ -38,6 +38,7 @@ export default function PageSchema() {
     <script
       key={idx}
       type="application/ld+json"
+      nonce={nonce}
       dangerouslySetInnerHTML={{ __html: JSON.stringify(ld).replace(/</g, "\\u003c") }}
     />
   ));

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { jwtVerify } from 'jose'
 import { getRedirections } from './app/lib/redirections'
-import crypto from 'node:crypto'
+import { randomUUID } from 'crypto'
 
 function getModuleAction(pathname) {
   if (!pathname.startsWith('/admin')) return null;
@@ -36,7 +36,7 @@ export const config = {
 };
 
 export async function middleware(request) {
-  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  const nonce = Buffer.from(randomUUID()).toString('base64')
   const cspHeader = `
     default-src 'self';
     connect-src 'self' https://ipinfo.io https://cdn.tiny.cloud https://embed.tawk.to https://va.tawk.to wss://*.tawk.to https://www.googletagmanager.com https://www.google-analytics.com;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -64,10 +64,7 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=31536000; includeSubDomains'
           },
-          {
-            key: 'Content-Security-Policy',
-            value: "default-src 'self' https: blob:; connect-src 'self' https://ipinfo.io https://cdn.tiny.cloud https://embed.tawk.to https://va.tawk.to wss://*.tawk.to https://www.googletagmanager.com https://www.google-analytics.com; img-src 'self' https://cdn.tiny.cloud blob: data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tiny.cloud https://www.googletagmanager.com https://embed.tawk.to; style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud https://embed.tawk.to; font-src 'self' 'unsafe-inline' data: https://cdn.tiny.cloud"
-          }
+          // Content Security Policy is set via middleware with a nonce
         ]
       },
       {


### PR DESCRIPTION
## Summary
- generate CSP nonce in middleware
- allow tawk domains in CSP and pass nonce through headers
- inject nonce into inline scripts and analytics widgets
- load nonce in `TawkToWidget` and `PageSchema`
- set CSP through middleware instead of `next.config.mjs`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1cb35888328a3221508cff12bf6