### PR TITLE
Fix background color status persistence

### DIFF
--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -278,6 +278,7 @@ export default function Page({ params }) {
       bgColorStatus: blog.bg_color_status ?? false,
       bgColor: blog.bg_color || "",
     });
+    setBgColorStatusValue(blog.bg_color_status ?? false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blog]);
 

--- a/app/admin/blogs/[id]/edit/page.jsx
+++ b/app/admin/blogs/[id]/edit/page.jsx
@@ -278,6 +278,10 @@ export default function Page({ params }) {
       bgColorStatus: blog.bg_color_status ?? false,
       bgColor: blog.bg_color || "",
     });
+    // ensure watchers update with new values
+    form.setValue("bgColorStatus", blog.bg_color_status ?? false);
+    form.setValue("bgColor", blog.bg_color || "");
+    setStatus(String(blog.status ?? 1));
     setBgColorStatusValue(blog.bg_color_status ?? false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blog]);

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -315,6 +315,10 @@ function BlogAdd() {
           bgColorStatus: blog.bg_color_status ?? false,
           bgColor: blog.bg_color || "",
         });
+        // ensure watchers update with new values
+        form.setValue("bgColorStatus", blog.bg_color_status ?? false);
+        form.setValue("bgColor", blog.bg_color || "");
+        setStatus(String(blog.status ?? 1));
         setBgColorStatusValue(blog.bg_color_status ?? false);
       } catch (err) {
         router.replace("/admin/blogs");

--- a/app/admin/blogs/add/page.jsx
+++ b/app/admin/blogs/add/page.jsx
@@ -315,6 +315,7 @@ function BlogAdd() {
           bgColorStatus: blog.bg_color_status ?? false,
           bgColor: blog.bg_color || "",
         });
+        setBgColorStatusValue(blog.bg_color_status ?? false);
       } catch (err) {
         router.replace("/admin/blogs");
       }


### PR DESCRIPTION
## Summary
- ensure bg color toggle updates on load for editing
- ensure bg color toggle updates on load for draft blogs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c9054c5d483289c3e98416ddee041