### PR TITLE
Update lead move behaviour

### DIFF
--- a/app/store/use-lead-store.js
+++ b/app/store/use-lead-store.js
@@ -1,5 +1,10 @@
 import { create } from 'zustand'
 
+export const LEAD_STATUS = {
+  UPCOMING: 1,
+  CAREER: 2,
+}
+
 export const useLeadStore = create((set) => ({
   upcoming: null,
   career: null,
@@ -28,6 +33,30 @@ export const useLeadStore = create((set) => ({
     set((state) => {
       const { [id]: removed, ...rest } = state.leadDetails
       return { leadDetails: rest }
+    }),
+  moveLead: (id, status) =>
+    set((state) => {
+      const getId = (l) => l._id || l.id
+      let { upcoming, career } = state
+      if (status === LEAD_STATUS.CAREER) {
+        const lead = upcoming?.find((l) => getId(l) === id)
+        upcoming = upcoming?.filter((l) => getId(l) !== id) || null
+        if (lead) {
+          const updated = { ...lead, status }
+          career = career ? [updated, ...career] : [updated]
+        }
+      } else if (status === LEAD_STATUS.UPCOMING) {
+        const lead = career?.find((l) => getId(l) === id)
+        career = career?.filter((l) => getId(l) !== id) || null
+        if (lead) {
+          const updated = { ...lead, status }
+          upcoming = upcoming ? [updated, ...upcoming] : [updated]
+        }
+      }
+      const leadDetails = state.leadDetails[id]
+        ? { ...state.leadDetails, [id]: { ...state.leadDetails[id], status } }
+        : state.leadDetails
+      return { upcoming, career, leadDetails }
     }),
 }))
 

--- a/components/leadTable.jsx
+++ b/components/leadTable.jsx
@@ -42,14 +42,14 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import apiFetch from "@/helpers/apiFetch";
+import { useLeadStore } from "@/app/store/use-lead-store";
 import { getPublicUrl } from "@/lib/s3";
 
 function LeadActions({ lead }) {
-  const router = useRouter();
   const [openAttachments, setOpenAttachments] = React.useState(false);
+  const moveLead = useLeadStore((state) => state.moveLead);
 
   const handleStatusChange = async (status) => {
     try {
@@ -62,7 +62,7 @@ function LeadActions({ lead }) {
       const data = await res.json();
       if (data.success) {
         toast.success("Status updated");
-        router.refresh();
+        moveLead(lead.id, status);
       } else {
         toast.error(data.error || "Failed to update status");
       }


### PR DESCRIPTION
## Summary
- update lead store with move helper
- update LeadTable actions to locally remove moved leads

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cf465591c8328bcfa14a9d700111f