### PR TITLE
Use Drawer for mobile admin sidebar

### DIFF
--- a/components/ui/drawer.jsx
+++ b/components/ui/drawer.jsx
@@ -1,0 +1,90 @@
+"use client"
+
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+function Drawer({ shouldScaleBackground = true, ...props }) {
+  return (
+    <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} {...props} />
+  )
+}
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+const DrawerPortal = DrawerPrimitive.Portal
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+function DrawerHeader({ className, ...props }) {
+  return (
+    <div className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)} {...props} />
+  )
+}
+DrawerHeader.displayName = "DrawerHeader"
+
+function DrawerFooter({ className, ...props }) {
+  return (
+    <div className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />
+  )
+}
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}
+

--- a/components/ui/sidebar.jsx
+++ b/components/ui/sidebar.jsx
@@ -11,12 +11,12 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet"
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Tooltip,
@@ -163,25 +163,23 @@ function Sidebar({
 
   if (isMobile) {
     return (
-      (<Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
-        <SheetContent
-          data-sidebar="sidebar"
-          data-slot="sidebar"
-          data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
-          style={
-            {
-              "--sidebar-width": SIDEBAR_WIDTH_MOBILE
-            }
-          }
-          side={side}>
-          <SheetHeader className="sr-only">
-            <SheetTitle>Sidebar</SheetTitle>
-            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
-          </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
-        </SheetContent>
-      </Sheet>)
+      (
+        <Drawer open={openMobile} onOpenChange={setOpenMobile} {...props}>
+          <DrawerContent
+            data-sidebar="sidebar"
+            data-slot="sidebar"
+            data-mobile="true"
+            className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0"
+            style={{ "--sidebar-width": SIDEBAR_WIDTH_MOBILE }}
+          >
+            <DrawerHeader className="sr-only">
+              <DrawerTitle>Sidebar</DrawerTitle>
+              <DrawerDescription>Displays the mobile sidebar.</DrawerDescription>
+            </DrawerHeader>
+            <div className="flex h-full w-full flex-col">{children}</div>
+          </DrawerContent>
+        </Drawer>
+      )
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "swiper": "^11.2.8",
     "tailwind-merge": "^3.3.0",
     "tinymce": "^7.9.1",
+    "vaul": "^1.1.2",
     "web-push": "^3.6.7",
     "zod": "^3.25.64",
     "zustand": "^5.0.5"


### PR DESCRIPTION
## Summary
- add `vaul` dependency for Drawer
- add Drawer UI component based on shadcn/ui
- swap mobile Sidebar Sheet with Drawer

## Testing
- `npm run lint`
- `npm run build` *(fails: No key set vapidDetails.publicKey)*

------
https://chatgpt.com/codex/tasks/task_e_686e0b8639488328aed92ec8311dd2a2