### PR TITLE
Fix department select visibility for admin profile

### DIFF
--- a/app/admin/profile/edit/page.jsx
+++ b/app/admin/profile/edit/page.jsx
@@ -27,7 +27,7 @@ export default function Page() {
         <CardContent className="max-sm:px-0">
           <EditAdminForm
             admin={profile}
-            hideDepartment={profile.role === 'superadmin'}
+            hideDepartment={profile.role !== 'superadmin'}
             redirectTo="/admin/profile"
           />
         </CardContent>


### PR DESCRIPTION
## Summary
- ensure department select only visible when role is `superadmin`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68750b4be9548328b764302ad7cab19c