### PR TITLE
Add page-level ContactUs defaults

### DIFF
--- a/app/(frontend)/about-us.php/page.jsx
+++ b/app/(frontend)/about-us.php/page.jsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import getDynamicMeta from "@/helpers/getDynamicMeta";
+import ContactUs from "@/components/ContactUs";
 
 export async function generateMetadata() {
   return await getDynamicMeta("/about-us.php");
@@ -523,6 +524,7 @@ export default function AboutUs() {
               </div>
           </div>
       </section>
+      <ContactUs defaultType="Fantasy Cricket App Development" />
     </>
   );
 }

--- a/app/(frontend)/career.php/page.jsx
+++ b/app/(frontend)/career.php/page.jsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import getDynamicMeta from "@/helpers/getDynamicMeta";
+import ContactUs from "@/components/ContactUs";
 
 export async function generateMetadata() {
   return await getDynamicMeta("/career.php");
@@ -553,7 +554,8 @@ export default function Career() {
                   <div className="text-sky-500 font-semibold text-base text-center ">Share your resume at</div>
                   <div className="text-black font-semibold text-base text-center select-all">hr@imgglobalinfotech.com</div>
               </div>
-          </div>
+        </div>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/app/(frontend)/casestudy.php/page.jsx
+++ b/app/(frontend)/casestudy.php/page.jsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import ContactUs from "@/components/ContactUs";
 
 export default function CaseStudy() {
     return (
@@ -583,6 +584,7 @@ export default function CaseStudy() {
                 </div>
             </div>
         </div>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/app/(frontend)/disclaimer.php/page.jsx
+++ b/app/(frontend)/disclaimer.php/page.jsx
@@ -1,3 +1,5 @@
+import ContactUs from "@/components/ContactUs";
+
 export default function Disclaimer() {
     return (
         <>
@@ -25,6 +27,7 @@ export default function Disclaimer() {
                     </div>
                 </div>
             </div>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/app/(frontend)/food-delivery-app-development.php/page.jsx
+++ b/app/(frontend)/food-delivery-app-development.php/page.jsx
@@ -4,6 +4,7 @@ import Svg from "@/components/svg";
 import Image from "next/image";
 import Link from "next/link";
 import { Swiper, SwiperSlide, Navigation, Autoplay } from '@/components/CustomSwiper';
+import ContactUs from "@/components/ContactUs";
 
 
 export default function FoodDeliveryAppDevelopment() {
@@ -1248,7 +1249,8 @@ export default function FoodDeliveryAppDevelopment() {
                         </div>
                     </div>
                 </div>
-            </section>
+        </section>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/app/(frontend)/grocery-app-development.php/page.jsx
+++ b/app/(frontend)/grocery-app-development.php/page.jsx
@@ -4,6 +4,7 @@ import Svg from "@/components/svg";
 import Image from "next/image";
 import Link from "next/link";
 import { Swiper, SwiperSlide, Navigation, Autoplay } from '@/components/CustomSwiper';
+import ContactUs from "@/components/ContactUs";
 
 
 export default function GroceryAppDevelopment() {
@@ -1243,7 +1244,8 @@ export default function GroceryAppDevelopment() {
                         </div>
                     </div>
                 </div>
-            </section>
+        </section>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/app/(frontend)/instant-delivery-app-development-company.php/page.jsx
+++ b/app/(frontend)/instant-delivery-app-development-company.php/page.jsx
@@ -4,6 +4,7 @@ import Svg from "@/components/svg";
 import Image from "next/image";
 import { useEffect, useRef } from 'react';
 import { Swiper, SwiperSlide, Navigation, Autoplay } from '@/components/CustomSwiper';
+import ContactUs from "@/components/ContactUs";
 
 
 export default function InstantDeliveryAppDevelopmentCompany() {
@@ -1306,7 +1307,8 @@ export default function InstantDeliveryAppDevelopmentCompany() {
                         </Swiper>
                     </div>
                 </div>
-            </section>
+        </section>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/app/(frontend)/layout.jsx
+++ b/app/(frontend)/layout.jsx
@@ -7,7 +7,6 @@ import { GoogleAnalytics } from '@next/third-parties/google'
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import schemaToLd from "@/helpers/schemaToLd";
 import getStaticMeta from "@/helpers/getStaticMeta";
-import ContactUs from "@/components/ContactUs";
 
 
 export async function generateMetadata() {
@@ -73,7 +72,6 @@ export default async function RootLayout({ children }) {
         {children}
         </main>
         <LeadPopup/>
-        <ContactUs/>
         <Footer/>
         {isProd && (
           <>

--- a/app/(frontend)/page.jsx
+++ b/app/(frontend)/page.jsx
@@ -24,6 +24,7 @@ const Testimonial = dynamic(() => import('@/components/testimonials/Testimonial1
 import Faq from '@/components/Faq';
 import HomeHeroSkeleton from '@/components/skeleton/HomeHeroSkeleton';
 import getDynamicMeta from '@/helpers/getDynamicMeta';
+import ContactUs from '@/components/ContactUs';
 
 export async function generateMetadata() {
   return await getDynamicMeta('/');
@@ -47,6 +48,7 @@ export default function Home() {
       <Usp/>
       <Testimonial/>
       <Faq/>
+      <ContactUs defaultType="Mobile App Development" />
     </>
   );
 }

--- a/app/(frontend)/taxi-app-development-company.php/page.jsx
+++ b/app/(frontend)/taxi-app-development-company.php/page.jsx
@@ -4,6 +4,7 @@ import Svg from "@/components/svg";
 import Image from "next/image";
 import Link from "next/link";
 import { Swiper, SwiperSlide, Navigation, Autoplay } from '@/components/CustomSwiper';
+import ContactUs from "@/components/ContactUs";
 
 
 export default function GroceryAppDevelopment() {
@@ -1383,7 +1384,8 @@ export default function GroceryAppDevelopment() {
                         </div>
                     </div>
                 </div>
-            </section>
+        </section>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/app/(frontend)/testimonials.php/page.jsx
+++ b/app/(frontend)/testimonials.php/page.jsx
@@ -3,6 +3,7 @@
 import Testimonial from "@/components/testimonials/Testimonial1";
 import Image from "next/image";
 import { Swiper, SwiperSlide, Autoplay } from '@/components/CustomSwiper';
+import ContactUs from "@/components/ContactUs";
 
 
 export default function Testimonials() {
@@ -578,7 +579,8 @@ export default function Testimonials() {
                         </div>
                     </div>
                 </div>
-            </section>
+        </section>
+        <ContactUs defaultType="Mobile App Development" />
         </>
     );
 }

--- a/components/ContactUs.jsx
+++ b/components/ContactUs.jsx
@@ -1,8 +1,16 @@
-import Svg from "@/components/svg"
-import Image from "next/image"
-import LeadForm from "@/components/leadForm"
+"use client";
+import Svg from "@/components/svg";
+import Image from "next/image";
+import LeadForm from "@/components/leadForm";
+import { usePathname } from "next/navigation";
 
-const ContactUs = () => {
+const defaultMap = {
+  "/": "Mobile App Development",
+  "/about-us.php": "Fantasy Cricket App Development",
+};
+const ContactUs = ({ defaultType }) => {
+    const pathname = usePathname();
+    const computedType = defaultType || defaultMap[pathname] || "Mobile App Development";
     return (
         <section className="contactSection w-full group/cs relative overflow-hidden bg-white">
             <div className="!container flex xl:py-16 lg:py-14 md:py-12 sm:py-10 py-8">
@@ -21,7 +29,7 @@ const ContactUs = () => {
                         </div>
                         <div className="xl:w-5/12 md:w-1/2 w-full flex flex-col md:px-4 px-2 relative">
                             <div className="w-full flex flex-col bg-white md:shadow-[0px_4px_14px_0px_#0000001F] shadow-[0px_2.61px_9.15px_0px_#0000001F] md:rounded-4xl rounded-2xl lg:p-8 py-5 px-4 [&_form]:pe-0">
-                                <LeadForm/>
+                                <LeadForm defaultType={computedType} />
                                 <ul className="grid grid-cols-6 gap-3 lg:pt-8 pt-5">
                                     <li className="relative">
                                         <Image src="https://d1y41eupgbwbb2.cloudfront.net/images/cocacolaLogo2.webp" className="w-full h-8 object-contain object-center aspect-[71/32]" width="71" height="32" alt="Coca-Cola" title="Coca-Cola" />

--- a/components/leadForm.jsx
+++ b/components/leadForm.jsx
@@ -1,77 +1,195 @@
-import Svg from "@/components/svg"
+"use client";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import PhoneInput from "@/components/ui/phone-input";
+import { toast } from "sonner";
 
-const LeadForm = () => {
-    return (
-        <form className="group/lead relative flex flex-col rounded md:mx-0 sm:rounded-2xl leadForm has-[button:disabled]:pointer-events-none overflow-y-auto [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar]:bg-black/5 [&::-webkit-scrollbar-thumb]:bg-black/10 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar]:rounded-full md:pe-2 pe-1">
-            <div className="grid grid-cols-2 gap-2">
-                <div className="relative md:mb-4 mb-2">
-                    <input type="text" id="name" className="block rounded-[15px] border border-[#B2C1F9] pr-2.5 ps-10 pb-2.5 pt-5 w-full text-sm appearance-none text-black focus:border-gray-500 focus:outline-none focus:ring-0 peer [&:user-invalid]:border-red-500" />
-                    <label htmlFor="name" className="absolute text-sm text-gray-400 duration-300 pointer-events-none transform -translate-y-4 scale-75 top-4 z-10 origin-[0] start-2.5 peer-focus:text-gray-400 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-4 peer-placeholder-shown:start-10 peer-focus:start-2.5">Full Name <span className="text-red-500 font-bold">*</span></label>
-                    <span className="absolute start-3 top-[1.45rem] text-gray-400 peer-placeholder-shown:top-[1.15rem] peer-focus:top-[1.45rem] duration-300 *:w-4 *:h-4">
-                        <Svg name="user" />
-                    </span>
-                </div>
-                <div className="relative md:mb-4 mb-2">
-                    <input type="email" id="emailID" className="block rounded-[15px] border border-[#B2C1F9] pr-2.5 ps-10 pb-2.5 pt-5 w-full text-sm appearance-none text-black focus:border-gray-500 focus:outline-none focus:ring-0 peer [&:user-invalid]:border-red-500"/>
-                    <label htmlFor="emailID" className="absolute text-sm text-gray-400 duration-300 pointer-events-none transform -translate-y-4 scale-75 top-4 z-10 origin-[0] start-2.5 peer-focus:text-gray-400 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-4 peer-placeholder-shown:start-10 peer-focus:start-2.5">Email ID <span className="text-red-500 font-bold">*</span></label>
-                    <span className="absolute start-3 top-[1.45rem] text-gray-400 peer-placeholder-shown:top-[1.15rem] peer-focus:top-[1.45rem] duration-300 *:w-4 *:h-4">
-                        <Svg name="email" />
-                    </span>
-                </div>
-            </div>
-            <div className="relative mb-4 [&_.iti--allow-dropdown]:after:content-['Please_enter_a_valid_phone_number.'] [&_.iti--allow-dropdown]:after:text-red-500 [&_.iti--allow-dropdown]:after:text-sm [&_.iti--allow-dropdown]:after:origin-left [&_.iti--allow-dropdown]:after:scale-0 [&_.iti--allow-dropdown]:after:h-0 [&_.iti--allow-dropdown]:after:overflow-hidden [&_.iti--allow-dropdown]:after:block [&_.iti--allow-dropdown]:after:duration-0 [&_.iti--allow-dropdown]:after:absolute [&_.iti--allow-dropdown]:after:bottom [&_.iti--allow-dropdown::after]:has-[input:user-invalid:focus]:h-5 [&_.iti--allow-dropdown::after]:has-[input:user-invalid:focus]:scale-100 has-[input:user-invalid:focus]:!mb-9 [&_.mobileNoErrorFooter]:has-[input:user-invalid]:!h-0 [&_.mobileNoErrorFooter]:has-[input:user-invalid]:!scale-0 [&_.iti\_\_selected-dial-code]:-mt-[1px] group-has-[.error:not(:empty)]/lead:has-[.phone-input:focus]:mb-9">
-                <input type="tel" id="phone" className="block phone-input rounded-[15px] border border-[#B2C1F9] pr-2.5 ps-10 pb-2.5 pt-5 w-full text-sm appearance-none text-black focus:border-gray-500 focus:outline-none focus:ring-0 peer group-has-[.error:not(:empty)]/lead:border-red-500 [&:user-invalid]:border-red-500" />
-                <label htmlFor="phone" className="absolute text-sm text-gray-400 duration-300 pointer-events-none transform -translate-y-4 scale-75 top-4 z-10 origin-[0] start-2.5 peer-focus:text-gray-400 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-4 peer-placeholder-shown:start-10 peer-focus:start-2.5">Mobile Number <span className="text-red-500 font-bold">*</span></label>
-                <span className="absolute start-3 bottom-3 invisible text-gray-400 peer-placeholder-shown:bottom-4 peer-focus:bottom-3 duration-300 *:w-4 *:h-4">
-                    <Svg name="email" />
-                </span>
-            </div>                   
-            
-            <div className="grid gap-3">
-                <div className="relative md:mb-4 mb-2">
-                    <select id="type" className="block rounded-[15px] border border-[#B2C1F9] pr-2.5 ps-10 pb-2.5 pt-5 w-full text-sm appearance-none text-black focus:border-gray-500 focus:outline-none focus:ring-0 peer [&:user-invalid]:border-red-500">
-                        <option value="Mobile App Development">Mobile App Development</option>
-                        <option value="Fantasy Cricket App Development">Fantasy Cricket App Development</option>
-                        <option value="Fantasy Sports App Development">Fantasy Sports App Development</option>
-                        <option value="Fantasy Football App Development">Fantasy Football App Development</option>
-                        <option value="E-commerce Development">E-commerce Development</option>
-                        <option value="MLM Software Development">MLM Software Development</option>
-                        <option value="Website Design">Website Design</option>
-                        <option value="Web Portal Development">Web Portal Development</option>
-                        <option value="Custom ERP Development">Custom ERP Development</option>
-                        <option value="Hire Dedicated Developer">Hire Dedicated Developer</option>
-                        <option value="SEO/Social Media Marketing">SEO/Social Media Marketing</option>
-                        <option value="Casino Game App Development">Casino Game App Development</option>
-                        <option value="Fantasy Kabaddi App Development">Fantasy Kabaddi App Development</option>
-                        <option value="Fantasy Stock Market App Development">Fantasy Stock Market App Development</option>
-                        <option value="Fantasy Stock Market App Development">Sports Betting App Development</option>
-                        <option value="Launch Your Online Ecommerce Store">Launch Your Online Ecommerce Store</option>
-                        <option value="Other Services">Other Services</option>
-                    </select>
-                    <label htmlFor="type" className="absolute text-sm text-gray-400 duration-300 pointer-events-none transform -translate-y-4 scale-75 top-4 z-10 origin-[0] start-2.5 peer-focus:text-gray-400 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-4 peer-placeholder-shown:start-10 peer-focus:start-2.5">Looking For <span className="text-red-500 font-bold">*</span></label>
-                    <span className="absolute start-3 top-[1.45rem] text-gray-400 peer-placeholder-shown:top-[1.15rem] peer-focus:top-[1.45rem] duration-300 *:w-4 *:h-4">
-                        <Svg name="dropdown" />
-                    </span>
-                </div>
-                
-            </div>
-            <div className="relative md:mb-4 mb-2">
-                <textarea id="Requierment" className=" block rounded-[15px] border border-[#B2C1F9] pr-2.5 ps-10 pb-2.5 pt-5 w-full text-sm appearance-none text-black focus:border-gray-500 focus:outline-none focus:ring-0 peer [&:user-invalid]:border-red-500"></textarea>
-                <label htmlFor="Requierment" className="absolute text-sm text-gray-400 duration-300 pointer-events-none transform -translate-y-4 scale-75 top-4 z-10 origin-[0] start-2.5 peer-focus:text-gray-400 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0 peer-focus:scale-75 peer-focus:-translate-y-4 peer-placeholder-shown:start-10 peer-focus:start-2.5">Write a Message <span className="text-red-500 font-bold">*</span></label>
-                <span className="absolute start-3 top-[1.45rem] text-gray-400 peer-placeholder-shown:top-[1.15rem] peer-focus:top-[1.45rem] duration-300 *:w-4 *:h-4">
-                    <Svg name="writeMessage" />
-                </span>
-            </div>
-            <button type="submit" className="inline-flex justify-center rounded-[15px] lg:mtauto text-sm font-semibold py-4 px-3 bg-slate-900 text-white [&:not(:disabled)]:hover:md:scale-90 duration-200 w-full group/submit">
-                <span className="group-[:disabled]/submit:hidden md:hidden">Let's Connect</span>
-                <span className="group-[:disabled]/submit:hidden max-md:hidden">Schedule Free Consultation</span>
-                <span className="group-[:disabled]/submit:flex items-center hidden">
-                    <Svg name="loader" className="inline w-4 h-4 me-3 text-white animate-spin" />
-                    Loading...
-                </span>
-            </button>
-        </form>
-    )
+const schema = z.object({
+  name: z.string().min(1, { message: "Name is required" }),
+  email: z.string().email({ message: "Invalid email" }),
+  phone: z.string().min(1, { message: "Mobile is required" }),
+  type: z.string().min(1, { message: "Service is required" }),
+  message: z.string().min(1, { message: "Message is required" }),
+});
+
+export default function LeadForm({ defaultType = "Mobile App Development" }) {
+  const [country, setCountry] = useState("in");
+
+  useEffect(() => {
+    async function detectCountry() {
+      try {
+        const res = await fetch("https://ipinfo.io/json");
+        const data = await res.json();
+        if (data && data.country) {
+          setCountry(data.country.toLowerCase());
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    detectCountry();
+  }, []);
+
+  const form = useForm({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: "",
+      email: "",
+      phone: "",
+      type: defaultType,
+      message: "",
+    },
+  });
+
+  async function onSubmit(values) {
+    try {
+      const fd = new FormData();
+      fd.append("contact_name", values.name);
+      fd.append("email", values.email);
+      fd.append("mobile_number", values.phone);
+      fd.append("requirements", values.type);
+      fd.append("description", values.message);
+      if (typeof window !== "undefined") {
+        fd.append("path", window.location.pathname);
+      }
+      const res = await fetch("/api/v1/admin/leads", {
+        method: "POST",
+        body: fd,
+      });
+      const data = await res.json();
+      if (data.success) {
+        toast.success("Submitted successfully");
+        form.reset();
+      } else {
+        toast.error(data.error || "Failed to submit");
+      }
+    } catch (err) {
+      toast.error("Failed to submit");
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 leadForm">
+        <div className="grid grid-cols-2 gap-2">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Full Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="Full Name" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email ID</FormLabel>
+                <FormControl>
+                  <Input type="email" placeholder="Email" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={form.control}
+          name="phone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Mobile Number</FormLabel>
+              <FormControl>
+                <PhoneInput
+                  value={field.value}
+                  onChange={field.onChange}
+                  defaultCountry={country}
+                  forceDialCode
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Looking For</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="Mobile App Development">Mobile App Development</SelectItem>
+                  <SelectItem value="Fantasy Cricket App Development">Fantasy Cricket App Development</SelectItem>
+                  <SelectItem value="Fantasy Sports App Development">Fantasy Sports App Development</SelectItem>
+                  <SelectItem value="Fantasy Football App Development">Fantasy Football App Development</SelectItem>
+                  <SelectItem value="E-commerce Development">E-commerce Development</SelectItem>
+                  <SelectItem value="MLM Software Development">MLM Software Development</SelectItem>
+                  <SelectItem value="Website Design">Website Design</SelectItem>
+                  <SelectItem value="Web Portal Development">Web Portal Development</SelectItem>
+                  <SelectItem value="Custom ERP Development">Custom ERP Development</SelectItem>
+                  <SelectItem value="Hire Dedicated Developer">Hire Dedicated Developer</SelectItem>
+                  <SelectItem value="SEO/Social Media Marketing">SEO/Social Media Marketing</SelectItem>
+                  <SelectItem value="Casino Game App Development">Casino Game App Development</SelectItem>
+                  <SelectItem value="Fantasy Kabaddi App Development">Fantasy Kabaddi App Development</SelectItem>
+                  <SelectItem value="Fantasy Stock Market App Development">Fantasy Stock Market App Development</SelectItem>
+                  <SelectItem value="Sports Betting App Development">Sports Betting App Development</SelectItem>
+                  <SelectItem value="Launch Your Online Ecommerce Store">Launch Your Online Ecommerce Store</SelectItem>
+                  <SelectItem value="Other Services">Other Services</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="message"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Write a Message</FormLabel>
+              <FormControl>
+                <Textarea placeholder="Message" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+          {form.formState.isSubmitting ? "Submitting..." : "Let's Connect"}
+        </Button>
+      </form>
+    </Form>
+  );
 }
-
-export default LeadForm


### PR DESCRIPTION
## Summary
- allow `ContactUs` to accept a `defaultType` prop
- use that prop in pages instead of layout so each page can choose its default service

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877474ba024832889fde204eec3f0ef