### PR TITLE
Capture contact form page URL

### DIFF
--- a/app/api/v1/admin/leads/[id]/route.js
+++ b/app/api/v1/admin/leads/[id]/route.js
@@ -68,6 +68,7 @@ export async function PUT(request, { params }) {
     lead.requirements = formData.get('requirements') || lead.requirements;
     lead.description = formData.get('description') || lead.description;
     lead.path = formData.get('path') || lead.path;
+    lead.page_url = formData.get('page_url') || lead.page_url;
     lead.assign_to = formData.get('assign_to') || lead.assign_to;
     lead.assigned_date = formData.get('assigned_date') ? new Date(formData.get('assigned_date')) : lead.assigned_date;
 

--- a/app/api/v1/admin/leads/route.js
+++ b/app/api/v1/admin/leads/route.js
@@ -43,6 +43,7 @@ export async function POST(request) {
       requirements: formData.get('requirements') || null,
       description: formData.get('description') || null,
       path: formData.get('path') || null,
+      page_url: formData.get('page_url') || null,
       assign_to: formData.get('assign_to') || null,
       assigned_date: formData.get('assigned_date') ? new Date(formData.get('assigned_date')) : null,
       attachments,

--- a/app/models/Lead.js
+++ b/app/models/Lead.js
@@ -15,6 +15,7 @@ const leadSchema = new mongoose.Schema(
     description: { type: String, default: null },
     attachments: { type: [String], default: [] },
     path: { type: String, default: null },
+    page_url: { type: String, default: null },
     assign_to: { type: mongoose.Schema.Types.ObjectId, ref: 'Admin', default: null },
     assigned_date: { type: Date, default: null },
     status: { type: Number, enum: [1, 2], default: LEAD_STATUS.UPCOMING },

--- a/components/leadForm.jsx
+++ b/components/leadForm.jsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/select";
 import PhoneInput from "@/components/ui/phone-input";
 import { toast } from "sonner";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 
 const schema = z.object({
     name: z.string().min(1, { message: "Name is required" }),
@@ -35,7 +35,18 @@ const schema = z.object({
 
 export default function LeadForm({ defaultType = "Mobile App Development" }) {
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const [pageUrl, setPageUrl] = useState("");
     const [country, setCountry] = useState("in");
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            const search = searchParams.toString();
+            const url = `${window.location.origin}${pathname}${search ? `?${search}` : ""}`;
+            setPageUrl(url);
+        }
+    }, [pathname, searchParams]);
 
     useEffect(() => {
         async function detectCountry() {
@@ -71,9 +82,8 @@ export default function LeadForm({ defaultType = "Mobile App Development" }) {
         fd.append("mobile_number", values.phone);
         fd.append("requirements", values.type);
         fd.append("description", values.message);
-        if (typeof window !== "undefined") {
-            fd.append("path", window.location.pathname);
-        }
+        fd.append("path", pathname);
+        fd.append("page_url", pageUrl);
         const res = await fetch("/api/v1/admin/leads", {
             method: "POST",
             body: fd,


### PR DESCRIPTION
## Summary
- store the originating page URL for lead submissions
- capture current page URL in the lead form and send it to the API

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68776ac0384c8328befc2516a1bb4b8e