### PR TITLE
Fix duplicate lead page URL storage

### DIFF
--- a/components/leadForm.jsx
+++ b/components/leadForm.jsx
@@ -79,8 +79,7 @@ export default function LeadForm({ defaultType = "Mobile App Development" }) {
         fd.append("mobile_number", values.phone);
         fd.append("requirements", values.type);
         fd.append("description", values.message);
-        fd.append("path", pathname);
-        fd.append("page_url", pageUrl);
+        fd.append("path", pageUrl);
         const res = await fetch("/api/v1/admin/leads", {
             method: "POST",
             body: fd,


### PR DESCRIPTION
## Summary
- remove `page_url` from lead form submissions
- store the full page URL in the `path` field instead

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877899df500832886549f77665e2ddb