### PR TITLE
Add slide state classes to carousel

### DIFF
--- a/components/ui/carousel.jsx
+++ b/components/ui/carousel.jsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import Autoplay from "embla-carousel-autoplay";
+import ClassNames from "embla-carousel-class-names";
 import { cn } from "@/lib/utils";
 
 const CarouselContext = React.createContext(null);
@@ -20,6 +21,7 @@ const Carousel = React.forwardRef(function Carousel(
 ) {
   const [emblaRef, emblaApi] = useEmblaCarousel(opts, [
     Autoplay({ delay: 5000, stopOnInteraction: false }),
+    ClassNames({ snapped: "is-snapped", inView: "is-in-view" }),
   ]);
   const [selectedIndex, setSelectedIndex] = React.useState(0);
 
@@ -32,6 +34,24 @@ const Carousel = React.forwardRef(function Carousel(
     onSelect();
     return () => emblaApi.off("select", onSelect);
   }, [emblaApi, setApi]);
+
+  React.useEffect(() => {
+    if (!emblaApi) return;
+    const slides = emblaApi.slideNodes();
+    const updatePrevNext = () => {
+      const selected = emblaApi.selectedScrollSnap();
+      const total = slides.length;
+      const prevIndex = (selected - 1 + total) % total;
+      const nextIndex = (selected + 1) % total;
+      slides.forEach((slide, index) => {
+        slide.classList.toggle("is-in-prev", index === prevIndex);
+        slide.classList.toggle("is-in-next", index === nextIndex);
+      });
+    };
+    updatePrevNext();
+    emblaApi.on("select", updatePrevNext);
+    return () => emblaApi.off("select", updatePrevNext);
+  }, [emblaApi]);
 
   return (
     <div ref={emblaRef} className={cn("relative overflow-hidden", className)} {...props}>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
     "embla-carousel-autoplay": "^8.6.0",
+    "embla-carousel-class-names": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "file-type": "^21.0.0",
     "fuse.js": "^7.1.0",


### PR DESCRIPTION
## Summary
- add `embla-carousel-class-names` plugin
- add `is-in-prev`/`is-in-next` support in carousel component

## Testing
- `npm run lint` *(fails: Cannot find module '@next/eslint-plugin-next')*

------
https://chatgpt.com/codex/tasks/task_e_6878cee0b0b0832883aa485931f912bd