### PR TITLE
Fix build warnings

### DIFF
--- a/app/(frontend)/layout.jsx
+++ b/app/(frontend)/layout.jsx
@@ -21,7 +21,10 @@ export default async function RootLayout({ children }) {
 
   async function getSchema(type) {
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/schema?global=true&type=${type}`, { cache: "no-store" });
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/schema?global=true&type=${type}`,
+        { next: { revalidate: 3600 } }
+      );
       const json = await res.json();
       return json.success && json.data ? json.data.data : null;
     } catch {

--- a/app/actions/pwa.js
+++ b/app/actions/pwa.js
@@ -4,11 +4,13 @@ import webpush from 'web-push'
 import connectDB from '../lib/db.js'
 import PushSubscription from '../models/PushSubscription.js'
 
-webpush.setVapidDetails(
-  'mailto:your-email@example.com',
-  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
-  process.env.VAPID_PRIVATE_KEY,
-)
+if (process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails(
+    'mailto:your-email@example.com',
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+    process.env.VAPID_PRIVATE_KEY,
+  )
+}
 
 export async function subscribeUser(sub) {
   await connectDB()

--- a/helpers/getDynamicMeta.js
+++ b/helpers/getDynamicMeta.js
@@ -2,7 +2,7 @@ export default async function getDynamicMeta(pageUrl) {
   try {
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/dynamic?pageUrl=${encodeURIComponent(pageUrl)}`,
-      { cache: 'no-store' }
+      { next: { revalidate: 3600 } }
     );
     const json = await res.json();
     if (json.success && json.data) {

--- a/helpers/getStaticMeta.js
+++ b/helpers/getStaticMeta.js
@@ -2,7 +2,7 @@ export default async function getStaticMeta() {
   try {
     const res = await fetch(
       `${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/admin/meta/static`,
-      { cache: 'no-store' }
+      { next: { revalidate: 3600 } }
     );
     const json = await res.json();
     if (json.success && json.data) {


### PR DESCRIPTION
## Summary
- avoid dynamic fetch by revalidating metadata
- adjust schema fetch in frontend layout
- guard web push initialization if credentials missing

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot read properties of null (reading 'useState')...)*

------
https://chatgpt.com/codex/tasks/task_e_687e205ac7648328a234414f1c07a6ab